### PR TITLE
get/set folder permission routes

### DIFF
--- a/pkg/api/folders.go
+++ b/pkg/api/folders.go
@@ -1,0 +1,42 @@
+// swagger:route GET /api/v1/folder/{Id}/permissions folders RouteGetFolderPermissions
+//
+// sets an Alerting config
+//
+//     Responses:
+//       200: Permissions
+//       400: ValidationError
+
+// swagger:route PUT /api/v1/folder/{Id}/permissions folders RouteSetFolderPermissions
+//
+// gets an Alerting config
+//
+//     Responses:
+//       201: Ack
+//       400: ValidationError
+
+package api
+
+import (
+	"github.com/grafana/grafana/pkg/api/dtos"
+)
+
+// swagger:model
+type Permissions []dtos.UpdateDashboardAclCommand
+
+// swagger:parameters RouteGetFolderPermissions
+type GetFolderPermsEndpointParams struct {
+	// Id of a folder
+	// in: path
+	Id string
+}
+
+// swagger:parameters RouteSetFolderPermissions
+type SetFolderPermsEndpointParams struct {
+	// Id of a folder
+	// in: path
+	Id string
+
+	// New folder permissions
+	// in: body
+	Body Permissions
+}

--- a/spec.json
+++ b/spec.json
@@ -222,6 +222,76 @@
         }
       }
     },
+    "/api/v1/folder/{Id}/permissions": {
+      "get": {
+        "description": "sets an Alerting config",
+        "tags": [
+          "folders"
+        ],
+        "operationId": "RouteGetFolderPermissions",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Id of a folder",
+            "name": "Id",
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Permissions",
+            "schema": {
+              "$ref": "#/definitions/Permissions"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      },
+      "put": {
+        "description": "gets an Alerting config",
+        "tags": [
+          "folders"
+        ],
+        "operationId": "RouteSetFolderPermissions",
+        "parameters": [
+          {
+            "type": "string",
+            "description": "Id of a folder",
+            "name": "Id",
+            "in": "path",
+            "required": true
+          },
+          {
+            "description": "New folder permissions",
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/Permissions"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Ack",
+            "schema": {
+              "$ref": "#/definitions/Ack"
+            }
+          },
+          "400": {
+            "description": "ValidationError",
+            "schema": {
+              "$ref": "#/definitions/ValidationError"
+            }
+          }
+        }
+      }
+    },
     "/api/v1/status/alerts": {
       "get": {
         "description": "gets the current alerts",
@@ -565,6 +635,28 @@
         }
       },
       "x-go-package": "github.com/prometheus/alertmanager/config"
+    },
+    "DashboardAclUpdateItem": {
+      "type": "object",
+      "properties": {
+        "permission": {
+          "$ref": "#/definitions/PermissionType"
+        },
+        "role": {
+          "$ref": "#/definitions/RoleType"
+        },
+        "teamId": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "TeamID"
+        },
+        "userId": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "UserID"
+        }
+      },
+      "x-go-package": "github.com/grafana/grafana/pkg/api/dtos"
     },
     "DateTime": {
       "description": "DateTime is a time but it serializes to ISO8601 format with millis\nIt knows how to read 3 different variations of a RFC3339 date time.\nMost APIs we encounter want either millisecond or second precision times.\nThis just tries to make it worry-free.",
@@ -1141,6 +1233,18 @@
       },
       "x-go-package": "github.com/prometheus/alertmanager/config"
     },
+    "PermissionType": {
+      "type": "integer",
+      "format": "int64",
+      "x-go-package": "github.com/grafana/grafana/pkg/models"
+    },
+    "Permissions": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/UpdateDashboardAclCommand"
+      },
+      "x-go-package": "github.com/grafana/alerting-api/pkg/api"
+    },
     "PushoverConfig": {
       "type": "object",
       "properties": {
@@ -1267,6 +1371,10 @@
       "type": "object",
       "title": "Regexp is the representation of a compiled regular expression.",
       "x-go-package": "regexp"
+    },
+    "RoleType": {
+      "type": "string",
+      "x-go-package": "github.com/grafana/grafana/pkg/models"
     },
     "Route": {
       "type": "object",
@@ -1688,9 +1796,8 @@
       "x-go-package": "github.com/prometheus/common/config"
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -1723,7 +1830,20 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "net/url"
+      "x-go-package": "github.com/prometheus/common/config"
+    },
+    "UpdateDashboardAclCommand": {
+      "type": "object",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DashboardAclUpdateItem"
+          },
+          "x-go-name": "Items"
+        }
+      },
+      "x-go-package": "github.com/grafana/grafana/pkg/api/dtos"
     },
     "UserConfig": {
       "type": "object",

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/acl.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/acl.go
@@ -1,0 +1,14 @@
+package dtos
+
+import "github.com/grafana/grafana/pkg/models"
+
+type UpdateDashboardAclCommand struct {
+	Items []DashboardAclUpdateItem `json:"items"`
+}
+
+type DashboardAclUpdateItem struct {
+	UserID     int64                 `json:"userId"`
+	TeamID     int64                 `json:"teamId"`
+	Role       *models.RoleType      `json:"role,omitempty"`
+	Permission models.PermissionType `json:"permission"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/alerting.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/alerting.go
@@ -1,0 +1,137 @@
+package dtos
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/null"
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+)
+
+func formatShort(interval time.Duration) string {
+	var result string
+
+	hours := interval / time.Hour
+	if hours > 0 {
+		result += fmt.Sprintf("%dh", hours)
+	}
+
+	remaining := interval - (hours * time.Hour)
+	mins := remaining / time.Minute
+	if mins > 0 {
+		result += fmt.Sprintf("%dm", mins)
+	}
+
+	remaining -= (mins * time.Minute)
+	seconds := remaining / time.Second
+	if seconds > 0 {
+		result += fmt.Sprintf("%ds", seconds)
+	}
+
+	return result
+}
+
+func NewAlertNotification(notification *models.AlertNotification) *AlertNotification {
+	dto := &AlertNotification{
+		Id:                    notification.Id,
+		Uid:                   notification.Uid,
+		Name:                  notification.Name,
+		Type:                  notification.Type,
+		IsDefault:             notification.IsDefault,
+		Created:               notification.Created,
+		Updated:               notification.Updated,
+		Frequency:             formatShort(notification.Frequency),
+		SendReminder:          notification.SendReminder,
+		DisableResolveMessage: notification.DisableResolveMessage,
+		Settings:              notification.Settings,
+		SecureFields:          map[string]bool{},
+	}
+
+	if notification.SecureSettings != nil {
+		for k := range notification.SecureSettings {
+			dto.SecureFields[k] = true
+		}
+	}
+
+	return dto
+}
+
+type AlertNotification struct {
+	Id                    int64            `json:"id"`
+	Uid                   string           `json:"uid"`
+	Name                  string           `json:"name"`
+	Type                  string           `json:"type"`
+	IsDefault             bool             `json:"isDefault"`
+	SendReminder          bool             `json:"sendReminder"`
+	DisableResolveMessage bool             `json:"disableResolveMessage"`
+	Frequency             string           `json:"frequency"`
+	Created               time.Time        `json:"created"`
+	Updated               time.Time        `json:"updated"`
+	Settings              *simplejson.Json `json:"settings"`
+	SecureFields          map[string]bool  `json:"secureFields"`
+}
+
+func NewAlertNotificationLookup(notification *models.AlertNotification) *AlertNotificationLookup {
+	return &AlertNotificationLookup{
+		Id:        notification.Id,
+		Uid:       notification.Uid,
+		Name:      notification.Name,
+		Type:      notification.Type,
+		IsDefault: notification.IsDefault,
+	}
+}
+
+type AlertNotificationLookup struct {
+	Id        int64  `json:"id"`
+	Uid       string `json:"uid"`
+	Name      string `json:"name"`
+	Type      string `json:"type"`
+	IsDefault bool   `json:"isDefault"`
+}
+
+type AlertTestCommand struct {
+	Dashboard *simplejson.Json `json:"dashboard" binding:"Required"`
+	PanelId   int64            `json:"panelId" binding:"Required"`
+}
+
+type AlertTestResult struct {
+	Firing         bool                  `json:"firing"`
+	State          models.AlertStateType `json:"state"`
+	ConditionEvals string                `json:"conditionEvals"`
+	TimeMs         string                `json:"timeMs"`
+	Error          string                `json:"error,omitempty"`
+	EvalMatches    []*EvalMatch          `json:"matches,omitempty"`
+	Logs           []*AlertTestResultLog `json:"logs,omitempty"`
+}
+
+type AlertTestResultLog struct {
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}
+
+type EvalMatch struct {
+	Tags   map[string]string `json:"tags,omitempty"`
+	Metric string            `json:"metric"`
+	Value  null.Float        `json:"value"`
+}
+
+type NotificationTestCommand struct {
+	ID                    int64             `json:"id,omitempty"`
+	Name                  string            `json:"name"`
+	Type                  string            `json:"type"`
+	SendReminder          bool              `json:"sendReminder"`
+	DisableResolveMessage bool              `json:"disableResolveMessage"`
+	Frequency             string            `json:"frequency"`
+	Settings              *simplejson.Json  `json:"settings"`
+	SecureSettings        map[string]string `json:"secureSettings"`
+}
+
+type PauseAlertCommand struct {
+	AlertId int64 `json:"alertId"`
+	Paused  bool  `json:"paused"`
+}
+
+type PauseAllAlertsCommand struct {
+	Paused bool `json:"paused"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/annotations.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/annotations.go
@@ -1,0 +1,43 @@
+package dtos
+
+import "github.com/grafana/grafana/pkg/components/simplejson"
+
+type PostAnnotationsCmd struct {
+	DashboardId int64            `json:"dashboardId"`
+	PanelId     int64            `json:"panelId"`
+	Time        int64            `json:"time"`
+	TimeEnd     int64            `json:"timeEnd,omitempty"` // Optional
+	Text        string           `json:"text"`
+	Tags        []string         `json:"tags"`
+	Data        *simplejson.Json `json:"data"`
+}
+
+type UpdateAnnotationsCmd struct {
+	Id      int64    `json:"id"`
+	Time    int64    `json:"time"`
+	TimeEnd int64    `json:"timeEnd,omitempty"` // Optional
+	Text    string   `json:"text"`
+	Tags    []string `json:"tags"`
+}
+
+type PatchAnnotationsCmd struct {
+	Id      int64    `json:"id"`
+	Time    int64    `json:"time"`
+	TimeEnd int64    `json:"timeEnd,omitempty"` // Optional
+	Text    string   `json:"text"`
+	Tags    []string `json:"tags"`
+}
+
+type DeleteAnnotationsCmd struct {
+	AlertId      int64 `json:"alertId"`
+	DashboardId  int64 `json:"dashboardId"`
+	PanelId      int64 `json:"panelId"`
+	AnnotationId int64 `json:"annotationId"`
+}
+
+type PostGraphiteAnnotationsCmd struct {
+	When int64       `json:"when"`
+	What string      `json:"what"`
+	Data string      `json:"data"`
+	Tags interface{} `json:"tags"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/apikey.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/apikey.go
@@ -1,0 +1,7 @@
+package dtos
+
+type NewApiKeyResult struct {
+	ID   int64  `json:"id"`
+	Name string `json:"name"`
+	Key  string `json:"key"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/dashboard.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/dashboard.go
@@ -1,0 +1,58 @@
+package dtos
+
+import (
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+)
+
+type DashboardMeta struct {
+	IsStarred             bool      `json:"isStarred,omitempty"`
+	IsHome                bool      `json:"isHome,omitempty"`
+	IsSnapshot            bool      `json:"isSnapshot,omitempty"`
+	Type                  string    `json:"type,omitempty"`
+	CanSave               bool      `json:"canSave"`
+	CanEdit               bool      `json:"canEdit"`
+	CanAdmin              bool      `json:"canAdmin"`
+	CanStar               bool      `json:"canStar"`
+	Slug                  string    `json:"slug"`
+	Url                   string    `json:"url"`
+	Expires               time.Time `json:"expires"`
+	Created               time.Time `json:"created"`
+	Updated               time.Time `json:"updated"`
+	UpdatedBy             string    `json:"updatedBy"`
+	CreatedBy             string    `json:"createdBy"`
+	Version               int       `json:"version"`
+	HasAcl                bool      `json:"hasAcl"`
+	IsFolder              bool      `json:"isFolder"`
+	FolderId              int64     `json:"folderId"`
+	FolderTitle           string    `json:"folderTitle"`
+	FolderUrl             string    `json:"folderUrl"`
+	Provisioned           bool      `json:"provisioned"`
+	ProvisionedExternalId string    `json:"provisionedExternalId"`
+}
+
+type DashboardFullWithMeta struct {
+	Meta      DashboardMeta    `json:"meta"`
+	Dashboard *simplejson.Json `json:"dashboard"`
+}
+
+type DashboardRedirect struct {
+	RedirectUri string `json:"redirectUri"`
+}
+
+type CalculateDiffOptions struct {
+	Base     CalculateDiffTarget `json:"base" binding:"Required"`
+	New      CalculateDiffTarget `json:"new" binding:"Required"`
+	DiffType string              `json:"diffType" binding:"Required"`
+}
+
+type CalculateDiffTarget struct {
+	DashboardId      int64            `json:"dashboardId"`
+	Version          int              `json:"version"`
+	UnsavedDashboard *simplejson.Json `json:"unsavedDashboard"`
+}
+
+type RestoreDashboardVersionCommand struct {
+	Version int `json:"version" binding:"Required"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/datasource.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/datasource.go
@@ -1,0 +1,63 @@
+package dtos
+
+import (
+	"strings"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/models"
+)
+
+type DataSource struct {
+	Id                int64            `json:"id"`
+	UID               string           `json:"uid"`
+	OrgId             int64            `json:"orgId"`
+	Name              string           `json:"name"`
+	Type              string           `json:"type"`
+	TypeLogoUrl       string           `json:"typeLogoUrl"`
+	Access            models.DsAccess  `json:"access"`
+	Url               string           `json:"url"`
+	Password          string           `json:"password"`
+	User              string           `json:"user"`
+	Database          string           `json:"database"`
+	BasicAuth         bool             `json:"basicAuth"`
+	BasicAuthUser     string           `json:"basicAuthUser"`
+	BasicAuthPassword string           `json:"basicAuthPassword"`
+	WithCredentials   bool             `json:"withCredentials"`
+	IsDefault         bool             `json:"isDefault"`
+	JsonData          *simplejson.Json `json:"jsonData,omitempty"`
+	SecureJsonFields  map[string]bool  `json:"secureJsonFields"`
+	Version           int              `json:"version"`
+	ReadOnly          bool             `json:"readOnly"`
+}
+
+type DataSourceListItemDTO struct {
+	Id          int64            `json:"id"`
+	UID         string           `json:"uid"`
+	OrgId       int64            `json:"orgId"`
+	Name        string           `json:"name"`
+	Type        string           `json:"type"`
+	TypeLogoUrl string           `json:"typeLogoUrl"`
+	Access      models.DsAccess  `json:"access"`
+	Url         string           `json:"url"`
+	Password    string           `json:"password"`
+	User        string           `json:"user"`
+	Database    string           `json:"database"`
+	BasicAuth   bool             `json:"basicAuth"`
+	IsDefault   bool             `json:"isDefault"`
+	JsonData    *simplejson.Json `json:"jsonData,omitempty"`
+	ReadOnly    bool             `json:"readOnly"`
+}
+
+type DataSourceList []DataSourceListItemDTO
+
+func (slice DataSourceList) Len() int {
+	return len(slice)
+}
+
+func (slice DataSourceList) Less(i, j int) bool {
+	return strings.ToLower(slice[i].Name) < strings.ToLower(slice[j].Name)
+}
+
+func (slice DataSourceList) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/folder.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/folder.go
@@ -1,0 +1,25 @@
+package dtos
+
+import "time"
+
+type Folder struct {
+	Id        int64     `json:"id"`
+	Uid       string    `json:"uid"`
+	Title     string    `json:"title"`
+	Url       string    `json:"url"`
+	HasAcl    bool      `json:"hasAcl"`
+	CanSave   bool      `json:"canSave"`
+	CanEdit   bool      `json:"canEdit"`
+	CanAdmin  bool      `json:"canAdmin"`
+	CreatedBy string    `json:"createdBy"`
+	Created   time.Time `json:"created"`
+	UpdatedBy string    `json:"updatedBy"`
+	Updated   time.Time `json:"updated"`
+	Version   int       `json:"version"`
+}
+
+type FolderSearchHit struct {
+	Id    int64  `json:"id"`
+	Uid   string `json:"uid"`
+	Title string `json:"title"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/index.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/index.go
@@ -1,0 +1,64 @@
+package dtos
+
+import (
+	"github.com/grafana/grafana/pkg/setting"
+
+	"html/template"
+)
+
+type IndexViewData struct {
+	User                    *CurrentUser
+	Settings                map[string]interface{}
+	AppUrl                  string
+	AppSubUrl               string
+	GoogleAnalyticsId       string
+	GoogleTagManagerId      string
+	NavTree                 []*NavLink
+	BuildVersion            string
+	BuildCommit             string
+	Theme                   string
+	NewGrafanaVersionExists bool
+	NewGrafanaVersion       string
+	AppName                 string
+	AppNameBodyClass        string
+	FavIcon                 template.URL
+	AppleTouchIcon          template.URL
+	AppTitle                string
+	Sentry                  *setting.Sentry
+	ContentDeliveryURL      string
+	// Nonce is a cryptographic identifier for use with Content Security Policy.
+	Nonce string
+}
+
+const (
+	// These weights may be used by an extension to reliably place
+	// itself in relation to a particular item in the menu. The weights
+	// are negative to ensure that the default items are placed above
+	// any items with default weight.
+
+	WeightCreate = (iota - 20) * 100
+	WeightDashboard
+	WeightExplore
+	WeightProfile
+	WeightAlerting
+	WeightPlugin
+	WeightConfig
+	WeightAdmin
+	WeightHelp
+)
+
+type NavLink struct {
+	Id           string     `json:"id,omitempty"`
+	Text         string     `json:"text,omitempty"`
+	Description  string     `json:"description,omitempty"`
+	SubTitle     string     `json:"subTitle,omitempty"`
+	Icon         string     `json:"icon,omitempty"`
+	Img          string     `json:"img,omitempty"`
+	Url          string     `json:"url,omitempty"`
+	Target       string     `json:"target,omitempty"`
+	SortWeight   int64      `json:"sortWeight,omitempty"`
+	Divider      bool       `json:"divider,omitempty"`
+	HideFromMenu bool       `json:"hideFromMenu,omitempty"`
+	HideFromTabs bool       `json:"hideFromTabs,omitempty"`
+	Children     []*NavLink `json:"children,omitempty"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/invite.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/invite.go
@@ -1,0 +1,26 @@
+package dtos
+
+import "github.com/grafana/grafana/pkg/models"
+
+type AddInviteForm struct {
+	LoginOrEmail string          `json:"loginOrEmail" binding:"Required"`
+	Name         string          `json:"name"`
+	Role         models.RoleType `json:"role" binding:"Required"`
+	SendEmail    bool            `json:"sendEmail"`
+}
+
+type InviteInfo struct {
+	Email     string `json:"email"`
+	Name      string `json:"name"`
+	Username  string `json:"username"`
+	InvitedBy string `json:"invitedBy"`
+}
+
+type CompleteInviteForm struct {
+	InviteCode      string `json:"inviteCode"`
+	Email           string `json:"email" binding:"Required"`
+	Name            string `json:"name"`
+	Username        string `json:"username"`
+	Password        string `json:"password"`
+	ConfirmPassword string `json:"confirmPassword"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/models.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/models.go
@@ -1,0 +1,89 @@
+package dtos
+
+import (
+	"crypto/md5"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/models"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+var regNonAlphaNumeric = regexp.MustCompile("[^a-zA-Z0-9]+")
+
+type AnyId struct {
+	Id int64 `json:"id"`
+}
+
+type LoginCommand struct {
+	User     string `json:"user" binding:"Required"`
+	Password string `json:"password" binding:"Required"`
+	Remember bool   `json:"remember"`
+}
+
+type CurrentUser struct {
+	IsSignedIn                 bool              `json:"isSignedIn"`
+	Id                         int64             `json:"id"`
+	Login                      string            `json:"login"`
+	Email                      string            `json:"email"`
+	Name                       string            `json:"name"`
+	LightTheme                 bool              `json:"lightTheme"`
+	OrgCount                   int               `json:"orgCount"`
+	OrgId                      int64             `json:"orgId"`
+	OrgName                    string            `json:"orgName"`
+	OrgRole                    models.RoleType   `json:"orgRole"`
+	IsGrafanaAdmin             bool              `json:"isGrafanaAdmin"`
+	GravatarUrl                string            `json:"gravatarUrl"`
+	Timezone                   string            `json:"timezone"`
+	Locale                     string            `json:"locale"`
+	HelpFlags1                 models.HelpFlags1 `json:"helpFlags1"`
+	HasEditPermissionInFolders bool              `json:"hasEditPermissionInFolders"`
+}
+
+type MetricRequest struct {
+	From    string             `json:"from"`
+	To      string             `json:"to"`
+	Queries []*simplejson.Json `json:"queries"`
+	Debug   bool               `json:"debug"`
+}
+
+func GetGravatarUrl(text string) string {
+	if setting.DisableGravatar {
+		return setting.AppSubUrl + "/public/img/user_profile.png"
+	}
+
+	if text == "" {
+		return ""
+	}
+
+	hasher := md5.New()
+	if _, err := hasher.Write([]byte(strings.ToLower(text))); err != nil {
+		log.Warnf("Failed to hash text: %s", err)
+	}
+	return fmt.Sprintf(setting.AppSubUrl+"/avatar/%x", hasher.Sum(nil))
+}
+
+func GetGravatarUrlWithDefault(text string, defaultText string) string {
+	if text != "" {
+		return GetGravatarUrl(text)
+	}
+
+	text = regNonAlphaNumeric.ReplaceAllString(defaultText, "") + "@localhost"
+
+	return GetGravatarUrl(text)
+}
+
+func IsHiddenUser(userLogin string, signedInUser *models.SignedInUser, cfg *setting.Cfg) bool {
+	if userLogin == "" || signedInUser.IsGrafanaAdmin || userLogin == signedInUser.Login {
+		return false
+	}
+
+	if _, hidden := cfg.HiddenUsers[userLogin]; hidden {
+		return true
+	}
+
+	return false
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/org.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/org.go
@@ -1,0 +1,14 @@
+package dtos
+
+type UpdateOrgForm struct {
+	Name string `json:"name" binding:"Required"`
+}
+
+type UpdateOrgAddressForm struct {
+	Address1 string `json:"address1"`
+	Address2 string `json:"address2"`
+	City     string `json:"city"`
+	ZipCode  string `json:"zipcode"`
+	State    string `json:"state"`
+	Country  string `json:"country"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/playlist.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/playlist.go
@@ -1,0 +1,24 @@
+package dtos
+
+type PlaylistDashboard struct {
+	Id    int64  `json:"id"`
+	Slug  string `json:"slug"`
+	Title string `json:"title"`
+	Uri   string `json:"uri"`
+	Url   string `json:"url"`
+	Order int    `json:"order"`
+}
+
+type PlaylistDashboardsSlice []PlaylistDashboard
+
+func (slice PlaylistDashboardsSlice) Len() int {
+	return len(slice)
+}
+
+func (slice PlaylistDashboardsSlice) Less(i, j int) bool {
+	return slice[i].Order < slice[j].Order
+}
+
+func (slice PlaylistDashboardsSlice) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/plugins.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/plugins.go
@@ -1,0 +1,68 @@
+package dtos
+
+import (
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/plugins"
+)
+
+type PluginSetting struct {
+	Name          string                      `json:"name"`
+	Type          string                      `json:"type"`
+	Id            string                      `json:"id"`
+	Enabled       bool                        `json:"enabled"`
+	Pinned        bool                        `json:"pinned"`
+	Module        string                      `json:"module"`
+	BaseUrl       string                      `json:"baseUrl"`
+	Info          *plugins.PluginInfo         `json:"info"`
+	Includes      []*plugins.PluginInclude    `json:"includes"`
+	Dependencies  *plugins.PluginDependencies `json:"dependencies"`
+	JsonData      map[string]interface{}      `json:"jsonData"`
+	DefaultNavUrl string                      `json:"defaultNavUrl"`
+
+	LatestVersion string                        `json:"latestVersion"`
+	HasUpdate     bool                          `json:"hasUpdate"`
+	State         plugins.PluginState           `json:"state"`
+	Signature     plugins.PluginSignatureStatus `json:"signature"`
+	SignatureType plugins.PluginSignatureType   `json:"signatureType"`
+	SignatureOrg  string                        `json:"signatureOrg"`
+}
+
+type PluginListItem struct {
+	Name          string                        `json:"name"`
+	Type          string                        `json:"type"`
+	Id            string                        `json:"id"`
+	Enabled       bool                          `json:"enabled"`
+	Pinned        bool                          `json:"pinned"`
+	Info          *plugins.PluginInfo           `json:"info"`
+	LatestVersion string                        `json:"latestVersion"`
+	HasUpdate     bool                          `json:"hasUpdate"`
+	DefaultNavUrl string                        `json:"defaultNavUrl"`
+	Category      string                        `json:"category"`
+	State         plugins.PluginState           `json:"state"`
+	Signature     plugins.PluginSignatureStatus `json:"signature"`
+	SignatureType plugins.PluginSignatureType   `json:"signatureType"`
+	SignatureOrg  string                        `json:"signatureOrg"`
+}
+
+type PluginList []PluginListItem
+
+func (slice PluginList) Len() int {
+	return len(slice)
+}
+
+func (slice PluginList) Less(i, j int) bool {
+	return slice[i].Name < slice[j].Name
+}
+
+func (slice PluginList) Swap(i, j int) {
+	slice[i], slice[j] = slice[j], slice[i]
+}
+
+type ImportDashboardCommand struct {
+	PluginId  string                         `json:"pluginId"`
+	Path      string                         `json:"path"`
+	Overwrite bool                           `json:"overwrite"`
+	Dashboard *simplejson.Json               `json:"dashboard"`
+	Inputs    []plugins.ImportDashboardInput `json:"inputs"`
+	FolderId  int64                          `json:"folderId"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/prefs.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/prefs.go
@@ -1,0 +1,13 @@
+package dtos
+
+type Prefs struct {
+	Theme           string `json:"theme"`
+	HomeDashboardID int64  `json:"homeDashboardId"`
+	Timezone        string `json:"timezone"`
+}
+
+type UpdatePrefsCmd struct {
+	Theme           string `json:"theme"`
+	HomeDashboardID int64  `json:"homeDashboardId"`
+	Timezone        string `json:"timezone"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/short_url.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/short_url.go
@@ -1,0 +1,10 @@
+package dtos
+
+type ShortURL struct {
+	UID string `json:"uid"`
+	URL string `json:"url"`
+}
+
+type CreateShortURLCmd struct {
+	Path string `json:"path"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/user.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/user.go
@@ -1,0 +1,46 @@
+package dtos
+
+type SignUpForm struct {
+	Email string `json:"email" binding:"Required"`
+}
+
+type SignUpStep2Form struct {
+	Email    string `json:"email"`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Code     string `json:"code"`
+	OrgName  string `json:"orgName"`
+}
+
+type AdminCreateUserForm struct {
+	Email    string `json:"email"`
+	Login    string `json:"login"`
+	Name     string `json:"name"`
+	Password string `json:"password" binding:"Required"`
+	OrgId    int64  `json:"orgId"`
+}
+
+type AdminUpdateUserPasswordForm struct {
+	Password string `json:"password" binding:"Required"`
+}
+
+type AdminUpdateUserPermissionsForm struct {
+	IsGrafanaAdmin bool `json:"isGrafanaAdmin"`
+}
+
+type SendResetPasswordEmailForm struct {
+	UserOrEmail string `json:"userOrEmail" binding:"Required"`
+}
+
+type ResetUserPasswordForm struct {
+	Code            string `json:"code"`
+	NewPassword     string `json:"newPassword"`
+	ConfirmPassword string `json:"confirmPassword"`
+}
+
+type UserLookupDTO struct {
+	UserID    int64  `json:"userId"`
+	Login     string `json:"login"`
+	AvatarURL string `json:"avatarUrl"`
+}

--- a/vendor/github.com/grafana/grafana/pkg/api/dtos/user_token.go
+++ b/vendor/github.com/grafana/grafana/pkg/api/dtos/user_token.go
@@ -1,0 +1,16 @@
+package dtos
+
+import "time"
+
+type UserToken struct {
+	Id                     int64     `json:"id"`
+	IsActive               bool      `json:"isActive"`
+	ClientIp               string    `json:"clientIp"`
+	Device                 string    `json:"device"`
+	OperatingSystem        string    `json:"os"`
+	OperatingSystemVersion string    `json:"osVersion"`
+	Browser                string    `json:"browser"`
+	BrowserVersion         string    `json:"browserVersion"`
+	CreatedAt              time.Time `json:"createdAt"`
+	SeenAt                 time.Time `json:"seenAt"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -199,6 +199,7 @@ github.com/gorilla/websocket
 github.com/gosimple/slug
 # github.com/grafana/grafana v1.9.2-0.20210217182004-6c4be29655a6
 ## explicit
+github.com/grafana/grafana/pkg/api/dtos
 github.com/grafana/grafana/pkg/bus
 github.com/grafana/grafana/pkg/cmd/grafana-cli/logger
 github.com/grafana/grafana/pkg/components/gtime


### PR DESCRIPTION
Added two routes to get /set folder permissions.
This is rather naive, using hte same model from grafana  as payload and return body.
I see that grafana returns a lot more stuff with GET ,some related to dasboards only. Not sure that we should or can have all that right now