### PR TITLE
adds datasource param to ruler/prom route paths

### DIFF
--- a/pkg/api/alertmanager.go
+++ b/pkg/api/alertmanager.go
@@ -160,7 +160,12 @@ type BodyAlertingConfig struct {
 	Body UserConfig
 }
 
+// alertmanager routes
 // swagger:parameters RoutePostAlertingConfig RouteGetAlertingConfig RouteDeleteAlertingConfig RouteGetAmAlerts RoutePostAmAlerts RouteGetAmAlertGroups RouteGetSilences RouteCreateSilence RouteGetSilence RouteDeleteSilence RoutePostAlertingConfig
+// ruler routes
+// swagger:parameters RouteGetRulesConfig RoutePostNameRulesConfig RouteGetNamespaceRulesConfig RouteDeleteNamespaceRulesConfig RouteGetRulegGroupConfig RouteDeleteRuleGroupConfig
+// prom routes
+// swagger:parameters RouteGetRuleStatuses RouteGetAlertStatuses
 type DatasourceReference struct {
 	// in:path
 	DatasourceId string

--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -6,7 +6,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// swagger:route Get /ruler/api/v1/rules ruler RouteGetRulesConfig
+// swagger:route Get /ruler/{DatasourceId}/api/v1/rules ruler RouteGetRulesConfig
 //
 // List rule groups
 //
@@ -16,7 +16,7 @@ import (
 //     Responses:
 //       202: NamespaceConfigResponse
 
-// swagger:route POST /ruler/api/v1/rules/{Namespace} ruler RoutePostNameRulesConfig
+// swagger:route POST /ruler/{DatasourceId}/api/v1/rules/{Namespace} ruler RoutePostNameRulesConfig
 //
 // Creates or updates a rule group
 //
@@ -27,7 +27,7 @@ import (
 //     Responses:
 //       202: Ack
 
-// swagger:route Get /ruler/api/v1/rules/{Namespace} ruler RouteGetNamespaceRulesConfig
+// swagger:route Get /ruler/{DatasourceId}/api/v1/rules/{Namespace} ruler RouteGetNamespaceRulesConfig
 //
 // Get rule groups by namespace
 //
@@ -37,14 +37,14 @@ import (
 //     Responses:
 //       202: NamespaceConfigResponse
 
-// swagger:route Delete /ruler/api/v1/rules/{Namespace} ruler RouteDeleteNamespaceRulesConfig
+// swagger:route Delete /ruler/{DatasourceId}/api/v1/rules/{Namespace} ruler RouteDeleteNamespaceRulesConfig
 //
 // Delete namespace
 //
 //     Responses:
 //       202: Ack
 
-// swagger:route Get /ruler/api/v1/rules/{Namespace}/{Groupname} ruler RouteGetRulegGroupConfig
+// swagger:route Get /ruler/{DatasourceId}/api/v1/rules/{Namespace}/{Groupname} ruler RouteGetRulegGroupConfig
 //
 // Get rule group
 //
@@ -54,7 +54,7 @@ import (
 //     Responses:
 //       202: RuleGroupConfigResponse
 
-// swagger:route Delete /ruler/api/v1/rules/{Namespace}/{Groupname} ruler RouteDeleteRuleGroupConfig
+// swagger:route Delete /ruler/{DatasourceId}/api/v1/rules/{Namespace}/{Groupname} ruler RouteDeleteRuleGroupConfig
 //
 // Delete rule group
 //

--- a/pkg/api/prom.go
+++ b/pkg/api/prom.go
@@ -6,14 +6,14 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
-// swagger:route GET /prometheus/api/v1/rules prometheus RouteGetRuleStatuses
+// swagger:route GET /prometheus/{DatasourceId}/api/v1/rules prometheus RouteGetRuleStatuses
 //
 // gets the evaluation statuses of all rules
 //
 //     Responses:
 //       200: RuleResponse
 
-// swagger:route GET /prometheus/api/v1/alerts prometheus RouteGetAlertStatuses
+// swagger:route GET /prometheus/{DatasourceId}/api/v1/alerts prometheus RouteGetAlertStatuses
 //
 // gets the current alerts
 //

--- a/spec.json
+++ b/spec.json
@@ -580,13 +580,21 @@
         }
       }
     },
-    "/prometheus/api/v1/alerts": {
+    "/prometheus/{DatasourceId}/api/v1/alerts": {
       "get": {
         "description": "gets the current alerts",
         "tags": [
           "prometheus"
         ],
         "operationId": "RouteGetAlertStatuses",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "DatasourceId",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "AlertResponse",
@@ -597,13 +605,21 @@
         }
       }
     },
-    "/prometheus/api/v1/rules": {
+    "/prometheus/{DatasourceId}/api/v1/rules": {
       "get": {
         "description": "gets the evaluation statuses of all rules",
         "tags": [
           "prometheus"
         ],
         "operationId": "RouteGetRuleStatuses",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "DatasourceId",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "200": {
             "description": "RuleResponse",
@@ -614,7 +630,7 @@
         }
       }
     },
-    "/ruler/api/v1/rules": {
+    "/ruler/{DatasourceId}/api/v1/rules": {
       "get": {
         "description": "List rule groups",
         "produces": [
@@ -624,6 +640,14 @@
           "ruler"
         ],
         "operationId": "RouteGetRulesConfig",
+        "parameters": [
+          {
+            "type": "string",
+            "name": "DatasourceId",
+            "in": "path",
+            "required": true
+          }
+        ],
         "responses": {
           "202": {
             "description": "NamespaceConfigResponse",
@@ -634,7 +658,7 @@
         }
       }
     },
-    "/ruler/api/v1/rules/{Namespace}": {
+    "/ruler/{DatasourceId}/api/v1/rules/{Namespace}": {
       "get": {
         "description": "Get rule groups by namespace",
         "produces": [
@@ -645,6 +669,12 @@
         ],
         "operationId": "RouteGetNamespaceRulesConfig",
         "parameters": [
+          {
+            "type": "string",
+            "name": "DatasourceId",
+            "in": "path",
+            "required": true
+          },
           {
             "type": "string",
             "name": "Namespace",
@@ -672,6 +702,12 @@
         ],
         "operationId": "RoutePostNameRulesConfig",
         "parameters": [
+          {
+            "type": "string",
+            "name": "DatasourceId",
+            "in": "path",
+            "required": true
+          },
           {
             "type": "string",
             "name": "Namespace",
@@ -704,6 +740,12 @@
         "parameters": [
           {
             "type": "string",
+            "name": "DatasourceId",
+            "in": "path",
+            "required": true
+          },
+          {
+            "type": "string",
             "name": "Namespace",
             "in": "path",
             "required": true
@@ -719,7 +761,7 @@
         }
       }
     },
-    "/ruler/api/v1/rules/{Namespace}/{Groupname}": {
+    "/ruler/{DatasourceId}/api/v1/rules/{Namespace}/{Groupname}": {
       "get": {
         "description": "Get rule group",
         "produces": [
@@ -730,6 +772,12 @@
         ],
         "operationId": "RouteGetRulegGroupConfig",
         "parameters": [
+          {
+            "type": "string",
+            "name": "DatasourceId",
+            "in": "path",
+            "required": true
+          },
           {
             "type": "string",
             "name": "Namespace",
@@ -759,6 +807,12 @@
         ],
         "operationId": "RouteDeleteRuleGroupConfig",
         "parameters": [
+          {
+            "type": "string",
+            "name": "DatasourceId",
+            "in": "path",
+            "required": true
+          },
           {
             "type": "string",
             "name": "Namespace",


### PR DESCRIPTION
We'll likely need to do something similar for the testing & permissions routes, but I'll defer those for now.