### PR TITLE
Modifications for supporting migration of notification channels

### DIFF
--- a/pkg/api/alertmanager.go
+++ b/pkg/api/alertmanager.go
@@ -304,7 +304,5 @@ func (r *ApiReceiver) Type() ReceiverType {
 }
 
 type GrafanaReceivers struct {
-	// required: true
-	DefaultReceiver         *GrafanaReceiver   `yaml:"default_receiver" json:"default_receiver"`
 	GrafanaManagedReceivers []*GrafanaReceiver `yaml:"grafana_managed_receiver_configs,omitempty" json:"grafana_managed_receiver_configs,omitempty"`
 }

--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -158,7 +158,7 @@ type ExtendedUpsertAlertDefinitionCommand struct {
 	ExecutionErrorState ExecutionErrorState    `json:"exec_err_state" yaml:"exec_err_state"`
 	Settings            map[string]interface{} `json:"settings" yaml:"settings"`
 	// Receivers are optional and used for migrating notification channels of existing alerts
-	Receivers []*GrafanaReceiver `json:"receivers" yaml:"receivers"`
+	Receivers []string `json:"receivers" yaml:"receivers"`
 	// internal state
 	FolderUID      string   `json:"-" yaml:"-"`
 	DatasourceUIDs []string `json:"-" yaml:"-"`

--- a/spec.json
+++ b/spec.json
@@ -1057,13 +1057,7 @@
     },
     "ApiReceiver": {
       "type": "object",
-      "required": [
-        "default_receiver"
-      ],
       "properties": {
-        "default_receiver": {
-          "$ref": "#/definitions/GrafanaReceiver"
-        },
         "email_configs": {
           "type": "array",
           "items": {
@@ -1510,7 +1504,7 @@
           "description": "Receivers are optional and used for migrating notification channels of existing alerts",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/GrafanaReceiver"
+            "type": "string"
           },
           "x-go-name": "Receivers"
         },
@@ -1624,13 +1618,7 @@
     },
     "GrafanaReceivers": {
       "type": "object",
-      "required": [
-        "default_receiver"
-      ],
       "properties": {
-        "default_receiver": {
-          "$ref": "#/definitions/GrafanaReceiver"
-        },
         "grafana_managed_receiver_configs": {
           "type": "array",
           "items": {
@@ -2723,8 +2711,9 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -2757,7 +2746,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "github.com/prometheus/common/config"
+      "x-go-package": "net/url"
     },
     "UpdateDashboardAclCommand": {
       "type": "object",


### PR DESCRIPTION
- It adds `default_receiver`
- Is adds support for associating notification channels with rules (used for the migration)