### PR TITLE
Add receivers to grafana alert rule config

### DIFF
--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -157,6 +157,7 @@ type ExtendedUpsertAlertDefinitionCommand struct {
 	NoDataState         NoDataState            `json:"no_data_state" yaml:"no_data_state"`
 	ExecutionErrorState ExecutionErrorState    `json:"exec_err_state" yaml:"exec_err_state"`
 	Settings            map[string]interface{} `json:"settings" yaml:"settings"`
+	Receivers           []string               `json:"receivers" yaml:"receivers"`
 	// internal state
 	FolderUID      string   `json:"-" yaml:"-"`
 	DatasourceUIDs []string `json:"-" yaml:"-"`

--- a/spec.json
+++ b/spec.json
@@ -1551,6 +1551,13 @@
           ],
           "x-go-name": "NoDataState"
         },
+        "receivers": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "x-go-name": "Receivers"
+        },
         "settings": {
           "type": "object",
           "additionalProperties": {
@@ -2754,8 +2761,9 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -2788,7 +2796,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "github.com/prometheus/common/config"
+      "x-go-package": "net/url"
     },
     "UpdateDashboardAclCommand": {
       "type": "object",


### PR DESCRIPTION
Since we will be allowing to choose receivers for the dashboard alerts, shouldn't we be sending that info to the backend? This PR proposes to add that and the alert creation would also require it to send it to the notification delivery ([see](https://github.com/grafana/alerting-api/pull/11#issuecomment-787924767)).