### PR TITLE
Fix listing rules response

### DIFF
--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -88,7 +88,7 @@ type RuleGroupConfigResponse struct {
 }
 
 // swagger:model
-type NamespaceConfigResponse map[string]RuleGroupConfig
+type NamespaceConfigResponse map[string][]RuleGroupConfig
 
 // swagger:model
 type RuleGroupConfig struct {

--- a/post.json
+++ b/post.json
@@ -1103,7 +1103,10 @@
   },
   "NamespaceConfigResponse": {
    "additionalProperties": {
-    "$ref": "#/definitions/RuleGroupConfig"
+    "items": {
+     "$ref": "#/definitions/RuleGroupConfig"
+    },
+    "type": "array"
    },
    "type": "object",
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"

--- a/spec.json
+++ b/spec.json
@@ -1940,7 +1940,10 @@
     "NamespaceConfigResponse": {
       "type": "object",
       "additionalProperties": {
-        "$ref": "#/definitions/RuleGroupConfig"
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/RuleGroupConfig"
+        }
       },
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },


### PR DESCRIPTION
Change response of:
- /ruler/{DatasourceId}/api/v1/rules (List rule groups)
- /ruler/{DatasourceId}/api/v1/rules/{Namespace} (Get rule groups by namespace)
from `map[string]RuleGroupConfig` to `map[string][]RuleGroupConfig`
to conform with the existing [cortex implementation](https://github.com/cortexproject/cortex/blob/b3c87d71b8ac45a87308657309ce666ee1ee4028/pkg/ruler/rules/store.go#L49)