### PR TITLE
Update get silence response

### DIFF
--- a/pkg/api/alertmanager.go
+++ b/pkg/api/alertmanager.go
@@ -108,7 +108,7 @@ type SilenceBody struct {
 }
 
 // swagger:model
-type GettableSilences []amv2.GettableSilences
+type GettableSilences amv2.GettableSilences
 
 // swagger:model
 type GettableSilence amv2.GettableSilence

--- a/pkg/api/alertmanager.go
+++ b/pkg/api/alertmanager.go
@@ -111,7 +111,7 @@ type SilenceBody struct {
 type GettableSilences []amv2.GettableSilences
 
 // swagger:model
-type GettableSilence amv2.Silence
+type GettableSilence amv2.GettableSilence
 
 // swagger:model
 type GettableAlerts amv2.GettableAlerts

--- a/post.json
+++ b/post.json
@@ -840,11 +840,7 @@
    "$ref": "#/definitions/gettableSilence"
   },
   "GettableSilences": {
-   "items": {
-    "$ref": "#/definitions/gettableSilences"
-   },
-   "type": "array",
-   "x-go-package": "github.com/grafana/alerting-api/pkg/api"
+   "$ref": "#/definitions/gettableSilences"
   },
   "GlobalConfig": {
    "description": "GlobalConfig defines configuration parameters that are valid globally\nunless overwritten.",
@@ -2035,7 +2031,6 @@
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2068,9 +2063,9 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object",
-   "x-go-package": "net/url"
+   "x-go-package": "github.com/prometheus/common/config"
   },
   "UpdateAlertDefinitionCommand": {
    "properties": {

--- a/post.json
+++ b/post.json
@@ -837,7 +837,7 @@
    "$ref": "#/definitions/gettableAlerts"
   },
   "GettableSilence": {
-   "$ref": "#/definitions/silence"
+   "$ref": "#/definitions/gettableSilence"
   },
   "GettableSilences": {
    "items": {
@@ -2035,6 +2035,7 @@
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
   "URL": {
+   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2067,9 +2068,9 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "URL is a custom URL type that allows validation at configuration load time.",
+   "title": "A URL represents a parsed URL (technically, a URI reference).",
    "type": "object",
-   "x-go-package": "github.com/prometheus/common/config"
+   "x-go-package": "net/url"
   },
   "UpdateAlertDefinitionCommand": {
    "properties": {

--- a/spec.json
+++ b/spec.json
@@ -1675,11 +1675,7 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "GettableSilences": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/gettableSilences"
-      },
-      "x-go-package": "github.com/grafana/alerting-api/pkg/api"
+      "$ref": "#/definitions/gettableSilences"
     },
     "GlobalConfig": {
       "description": "GlobalConfig defines configuration parameters that are valid globally\nunless overwritten.",
@@ -2871,9 +2867,8 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -2906,7 +2901,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "net/url"
+      "x-go-package": "github.com/prometheus/common/config"
     },
     "UpdateAlertDefinitionCommand": {
       "type": "object",

--- a/spec.json
+++ b/spec.json
@@ -1672,7 +1672,7 @@
       "$ref": "#/definitions/gettableAlerts"
     },
     "GettableSilence": {
-      "$ref": "#/definitions/silence"
+      "$ref": "#/definitions/gettableSilence"
     },
     "GettableSilences": {
       "type": "array",
@@ -2871,8 +2871,9 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "URL": {
+      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "URL is a custom URL type that allows validation at configuration load time.",
+      "title": "A URL represents a parsed URL (technically, a URI reference).",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -2905,7 +2906,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "github.com/prometheus/common/config"
+      "x-go-package": "net/url"
     },
     "UpdateAlertDefinitionCommand": {
       "type": "object",


### PR DESCRIPTION
- Update GET /silence/{silenceID} to conform with [the existing API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/prometheus/alertmanager/master/api/v2/openapi.yaml#/silence/getSilence) and [the existing implementation](https://github.com/prometheus/alertmanager/blob/2b6315f399b95c4e327dcd5f5eb10866ef844252/api/v2/api.go#L682).

- Update GET /alertmanager/{DatasourceId}/api/v2/silences to conform with  [the existing API](https://petstore.swagger.io/?url=https://raw.githubusercontent.com/prometheus/alertmanager/master/api/v2/openapi.yaml#/silence/getSilences) and [the existing implementation](https://github.com/prometheus/alertmanager/blob/2b6315f399b95c4e327dcd5f5eb10866ef844252/api/v2/api.go#L585).