### PR TITLE
Fix yaml annotations for embedded type

### DIFF
--- a/post.json
+++ b/post.json
@@ -407,7 +407,7 @@
    },
    "title": "Config is the top-level configuration for Alertmanager's config files.",
    "type": "object",
-   "x-go-package": "github.com/prometheus/alertmanager/config"
+   "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
   "CreateAlertNotificationCommand": {
    "properties": {

--- a/spec.json
+++ b/spec.json
@@ -1171,7 +1171,7 @@
           "x-go-name": "Templates"
         }
       },
-      "x-go-package": "github.com/prometheus/alertmanager/config"
+      "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "CreateAlertNotificationCommand": {
       "type": "object",


### PR DESCRIPTION
This is required because we have to store (in the DB) the alert manager configuration in YAML.