### PR TITLE
Rename DatasourceId path parameter

### DIFF
--- a/pkg/api/alertmanager.go
+++ b/pkg/api/alertmanager.go
@@ -10,7 +10,7 @@ import (
 	"github.com/prometheus/alertmanager/config"
 )
 
-// swagger:route POST /alertmanager/{DatasourceId}/config/api/v1/alerts alertmanager RoutePostAlertingConfig
+// swagger:route POST /alertmanager/{Recipient}/config/api/v1/alerts alertmanager RoutePostAlertingConfig
 //
 // sets an Alerting config
 //
@@ -18,7 +18,7 @@ import (
 //       201: Ack
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{DatasourceId}/config/api/v1/alerts alertmanager RouteGetAlertingConfig
+// swagger:route GET /alertmanager/{Recipient}/config/api/v1/alerts alertmanager RouteGetAlertingConfig
 //
 // gets an Alerting config
 //
@@ -26,7 +26,7 @@ import (
 //       200: GettableUserConfig
 //       400: ValidationError
 
-// swagger:route DELETE /alertmanager/{DatasourceId}/config/api/v1/alerts alertmanager RouteDeleteAlertingConfig
+// swagger:route DELETE /alertmanager/{Recipient}/config/api/v1/alerts alertmanager RouteDeleteAlertingConfig
 //
 // deletes the Alerting config for a tenant
 //
@@ -34,7 +34,7 @@ import (
 //       200: Ack
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{DatasourceId}/api/v2/alerts alertmanager RouteGetAmAlerts
+// swagger:route GET /alertmanager/{Recipient}/api/v2/alerts alertmanager RouteGetAmAlerts
 //
 // get alertmanager alerts
 //
@@ -42,7 +42,7 @@ import (
 //       200: GettableAlerts
 //       400: ValidationError
 
-// swagger:route POST /alertmanager/{DatasourceId}/api/v2/alerts alertmanager RoutePostAmAlerts
+// swagger:route POST /alertmanager/{Recipient}/api/v2/alerts alertmanager RoutePostAmAlerts
 //
 // create alertmanager alerts
 //
@@ -50,7 +50,7 @@ import (
 //       200: Ack
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{DatasourceId}/api/v2/alerts/groups alertmanager RouteGetAmAlertGroups
+// swagger:route GET /alertmanager/{Recipient}/api/v2/alerts/groups alertmanager RouteGetAmAlertGroups
 //
 // get alertmanager alerts
 //
@@ -58,7 +58,7 @@ import (
 //       200: AlertGroups
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{DatasourceId}/api/v2/silences alertmanager RouteGetSilences
+// swagger:route GET /alertmanager/{Recipient}/api/v2/silences alertmanager RouteGetSilences
 //
 // get silences
 //
@@ -66,7 +66,7 @@ import (
 //       200: GettableSilences
 //       400: ValidationError
 
-// swagger:route POST /alertmanager/{DatasourceId}/api/v2/silences alertmanager RouteCreateSilence
+// swagger:route POST /alertmanager/{Recipient}/api/v2/silences alertmanager RouteCreateSilence
 //
 // create silence
 //
@@ -74,7 +74,7 @@ import (
 //       201: GettableSilence
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{DatasourceId}/api/v2/silence/{SilenceId} alertmanager RouteGetSilence
+// swagger:route GET /alertmanager/{Recipient}/api/v2/silence/{SilenceId} alertmanager RouteGetSilence
 //
 // get silence
 //
@@ -82,7 +82,7 @@ import (
 //       200: GettableSilence
 //       400: ValidationError
 
-// swagger:route DELETE /alertmanager/{DatasourceId}/api/v2/silence/{SilenceId} alertmanager RouteDeleteSilence
+// swagger:route DELETE /alertmanager/{Recipient}/api/v2/silence/{SilenceId} alertmanager RouteDeleteSilence
 //
 // delete silence
 //
@@ -168,8 +168,10 @@ type BodyAlertingConfig struct {
 // prom routes
 // swagger:parameters RouteGetRuleStatuses RouteGetAlertStatuses
 type DatasourceReference struct {
+	// Recipient should be "grafana" for requests to be handled by grafana
+	// and the numeric datasource id for requests to be forwarded to a datasource
 	// in:path
-	DatasourceId string
+	Recipient string
 }
 
 // swagger:model

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -31,7 +31,21 @@ type Ack struct{}
 type Backend int
 
 const (
-	GrafanaBackend Backend = iota
+	GrafanaBackend Backend = iota + 1
 	AlertmanagerBackend
 	LoTexRulerBackend
 )
+
+func (b Backend) String() string {
+	switch b {
+	case GrafanaBackend:
+		return "grafana"
+	case AlertmanagerBackend:
+		return "alertmanager"
+	case LoTexRulerBackend:
+		return "lotex"
+	default:
+		return ""
+	}
+
+}

--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -8,7 +8,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// swagger:route Get /ruler/{DatasourceId}/api/v1/rules ruler RouteGetRulesConfig
+// swagger:route Get /ruler/{Recipient}/api/v1/rules ruler RouteGetRulesConfig
 //
 // List rule groups
 //
@@ -18,7 +18,7 @@ import (
 //     Responses:
 //       202: NamespaceConfigResponse
 
-// swagger:route POST /ruler/{DatasourceId}/api/v1/rules/{Namespace} ruler RoutePostNameRulesConfig
+// swagger:route POST /ruler/{Recipient}/api/v1/rules/{Namespace} ruler RoutePostNameRulesConfig
 //
 // Creates or updates a rule group
 //
@@ -29,7 +29,7 @@ import (
 //     Responses:
 //       202: Ack
 
-// swagger:route Get /ruler/{DatasourceId}/api/v1/rules/{Namespace} ruler RouteGetNamespaceRulesConfig
+// swagger:route Get /ruler/{Recipient}/api/v1/rules/{Namespace} ruler RouteGetNamespaceRulesConfig
 //
 // Get rule groups by namespace
 //
@@ -39,14 +39,14 @@ import (
 //     Responses:
 //       202: NamespaceConfigResponse
 
-// swagger:route Delete /ruler/{DatasourceId}/api/v1/rules/{Namespace} ruler RouteDeleteNamespaceRulesConfig
+// swagger:route Delete /ruler/{Recipient}/api/v1/rules/{Namespace} ruler RouteDeleteNamespaceRulesConfig
 //
 // Delete namespace
 //
 //     Responses:
 //       202: Ack
 
-// swagger:route Get /ruler/{DatasourceId}/api/v1/rules/{Namespace}/{Groupname} ruler RouteGetRulegGroupConfig
+// swagger:route Get /ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname} ruler RouteGetRulegGroupConfig
 //
 // Get rule group
 //
@@ -56,7 +56,7 @@ import (
 //     Responses:
 //       202: RuleGroupConfigResponse
 
-// swagger:route Delete /ruler/{DatasourceId}/api/v1/rules/{Namespace}/{Groupname} ruler RouteDeleteRuleGroupConfig
+// swagger:route Delete /ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname} ruler RouteDeleteRuleGroupConfig
 //
 // Delete rule group
 //

--- a/pkg/api/prom.go
+++ b/pkg/api/prom.go
@@ -6,14 +6,14 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
-// swagger:route GET /prometheus/{DatasourceId}/api/v1/rules prometheus RouteGetRuleStatuses
+// swagger:route GET /prometheus/{Recipient}/api/v1/rules prometheus RouteGetRuleStatuses
 //
 // gets the evaluation statuses of all rules
 //
 //     Responses:
 //       200: RuleResponse
 
-// swagger:route GET /prometheus/{DatasourceId}/api/v1/alerts prometheus RouteGetAlertStatuses
+// swagger:route GET /prometheus/{Recipient}/api/v1/alerts prometheus RouteGetAlertStatuses
 //
 // gets the current alerts
 //

--- a/post.json
+++ b/post.json
@@ -2973,7 +2973,7 @@
   "version": "1.0.0"
  },
  "paths": {
-  "/alertmanager/{DatasourceId}/api/v2/alerts": {
+  "/alertmanager/{Recipient}/api/v2/alerts": {
    "get": {
     "description": "get alertmanager alerts",
     "operationId": "RouteGetAmAlerts",
@@ -3020,8 +3020,9 @@
       "x-go-name": "Receivers"
      },
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3059,8 +3060,9 @@
       }
      },
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3084,7 +3086,7 @@
     ]
    }
   },
-  "/alertmanager/{DatasourceId}/api/v2/alerts/groups": {
+  "/alertmanager/{Recipient}/api/v2/alerts/groups": {
    "get": {
     "description": "get alertmanager alerts",
     "operationId": "RouteGetAmAlertGroups",
@@ -3131,8 +3133,9 @@
       "x-go-name": "Receivers"
      },
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3156,7 +3159,7 @@
     ]
    }
   },
-  "/alertmanager/{DatasourceId}/api/v2/silence/{SilenceId}": {
+  "/alertmanager/{Recipient}/api/v2/silence/{SilenceId}": {
    "delete": {
     "description": "delete silence",
     "operationId": "RouteDeleteSilence",
@@ -3168,8 +3171,9 @@
       "type": "string"
      },
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3203,8 +3207,9 @@
       "type": "string"
      },
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3228,14 +3233,15 @@
     ]
    }
   },
-  "/alertmanager/{DatasourceId}/api/v2/silences": {
+  "/alertmanager/{Recipient}/api/v2/silences": {
    "get": {
     "description": "get silences",
     "operationId": "RouteGetSilences",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3270,8 +3276,9 @@
       }
      },
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3295,14 +3302,15 @@
     ]
    }
   },
-  "/alertmanager/{DatasourceId}/config/api/v1/alerts": {
+  "/alertmanager/{Recipient}/config/api/v1/alerts": {
    "delete": {
     "description": "deletes the Alerting config for a tenant",
     "operationId": "RouteDeleteAlertingConfig",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3330,8 +3338,9 @@
     "operationId": "RouteGetAlertingConfig",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3366,8 +3375,9 @@
       }
      },
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3467,14 +3477,15 @@
     ]
    }
   },
-  "/prometheus/{DatasourceId}/api/v1/alerts": {
+  "/prometheus/{Recipient}/api/v1/alerts": {
    "get": {
     "description": "gets the current alerts",
     "operationId": "RouteGetAlertStatuses",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3492,14 +3503,15 @@
     ]
    }
   },
-  "/prometheus/{DatasourceId}/api/v1/rules": {
+  "/prometheus/{Recipient}/api/v1/rules": {
    "get": {
     "description": "gets the evaluation statuses of all rules",
     "operationId": "RouteGetRuleStatuses",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3517,14 +3529,15 @@
     ]
    }
   },
-  "/ruler/{DatasourceId}/api/v1/rules": {
+  "/ruler/{Recipient}/api/v1/rules": {
    "get": {
     "description": "List rule groups",
     "operationId": "RouteGetRulesConfig",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      }
@@ -3545,14 +3558,15 @@
     ]
    }
   },
-  "/ruler/{DatasourceId}/api/v1/rules/{Namespace}": {
+  "/ruler/{Recipient}/api/v1/rules/{Namespace}": {
    "delete": {
     "description": "Delete namespace",
     "operationId": "RouteDeleteNamespaceRulesConfig",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      },
@@ -3580,8 +3594,9 @@
     "operationId": "RouteGetNamespaceRulesConfig",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      },
@@ -3616,8 +3631,9 @@
     "operationId": "RoutePostNameRulesConfig",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      },
@@ -3648,14 +3664,15 @@
     ]
    }
   },
-  "/ruler/{DatasourceId}/api/v1/rules/{Namespace}/{Groupname}": {
+  "/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}": {
    "delete": {
     "description": "Delete rule group",
     "operationId": "RouteDeleteRuleGroupConfig",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      },
@@ -3689,8 +3706,9 @@
     "operationId": "RouteGetRulegGroupConfig",
     "parameters": [
      {
+      "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
       "in": "path",
-      "name": "DatasourceId",
+      "name": "Recipient",
       "required": true,
       "type": "string"
      },

--- a/spec.json
+++ b/spec.json
@@ -16,7 +16,7 @@
   },
   "basePath": "/api/v1",
   "paths": {
-    "/alertmanager/{DatasourceId}/api/v2/alerts": {
+    "/alertmanager/{Recipient}/api/v2/alerts": {
       "get": {
         "description": "get alertmanager alerts",
         "tags": [
@@ -67,7 +67,8 @@
           },
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -106,7 +107,8 @@
           },
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -127,7 +129,7 @@
         }
       }
     },
-    "/alertmanager/{DatasourceId}/api/v2/alerts/groups": {
+    "/alertmanager/{Recipient}/api/v2/alerts/groups": {
       "get": {
         "description": "get alertmanager alerts",
         "tags": [
@@ -178,7 +180,8 @@
           },
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -199,7 +202,7 @@
         }
       }
     },
-    "/alertmanager/{DatasourceId}/api/v2/silence/{SilenceId}": {
+    "/alertmanager/{Recipient}/api/v2/silence/{SilenceId}": {
       "get": {
         "description": "get silence",
         "tags": [
@@ -215,7 +218,8 @@
           },
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -250,7 +254,8 @@
           },
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -271,7 +276,7 @@
         }
       }
     },
-    "/alertmanager/{DatasourceId}/api/v2/silences": {
+    "/alertmanager/{Recipient}/api/v2/silences": {
       "get": {
         "description": "get silences",
         "tags": [
@@ -281,7 +286,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -317,7 +323,8 @@
           },
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -338,7 +345,7 @@
         }
       }
     },
-    "/alertmanager/{DatasourceId}/config/api/v1/alerts": {
+    "/alertmanager/{Recipient}/config/api/v1/alerts": {
       "get": {
         "description": "gets an Alerting config",
         "tags": [
@@ -348,7 +355,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -384,7 +392,8 @@
           },
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -413,7 +422,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -510,7 +520,7 @@
         }
       }
     },
-    "/prometheus/{DatasourceId}/api/v1/alerts": {
+    "/prometheus/{Recipient}/api/v1/alerts": {
       "get": {
         "description": "gets the current alerts",
         "tags": [
@@ -520,7 +530,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -535,7 +546,7 @@
         }
       }
     },
-    "/prometheus/{DatasourceId}/api/v1/rules": {
+    "/prometheus/{Recipient}/api/v1/rules": {
       "get": {
         "description": "gets the evaluation statuses of all rules",
         "tags": [
@@ -545,7 +556,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -560,7 +572,7 @@
         }
       }
     },
-    "/ruler/{DatasourceId}/api/v1/rules": {
+    "/ruler/{Recipient}/api/v1/rules": {
       "get": {
         "description": "List rule groups",
         "produces": [
@@ -573,7 +585,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           }
@@ -588,7 +601,7 @@
         }
       }
     },
-    "/ruler/{DatasourceId}/api/v1/rules/{Namespace}": {
+    "/ruler/{Recipient}/api/v1/rules/{Namespace}": {
       "get": {
         "description": "Get rule groups by namespace",
         "produces": [
@@ -601,7 +614,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           },
@@ -634,7 +648,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           },
@@ -670,7 +685,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           },
@@ -691,7 +707,7 @@
         }
       }
     },
-    "/ruler/{DatasourceId}/api/v1/rules/{Namespace}/{Groupname}": {
+    "/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}": {
       "get": {
         "description": "Get rule group",
         "produces": [
@@ -704,7 +720,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           },
@@ -739,7 +756,8 @@
         "parameters": [
           {
             "type": "string",
-            "name": "DatasourceId",
+            "description": "Recipient should be \"grafana\" for requests to be handled by grafana\nand the numeric datasource id for requests to be forwarded to a datasource",
+            "name": "Recipient",
             "in": "path",
             "required": true
           },


### PR DESCRIPTION
We hope that this would be less confusing for grafana users. 

Its value should be `grafana` for requests to be handled by grafana and the numeric datasource id for requests to be forwarded to a lotex datasource.

The chosen name `Recipient` is discussable.

**Update**
I have added a 0ed8a62ac063dbc0ad23c56d251d6e2234884ef8 which is also [required](https://github.com/grafana/grafana/pull/32208#discussion_r598828511) for grafana/grafana#32208.