### PR TITLE
Fix GO initialisms

### DIFF
--- a/pkg/api/alertmanager.go
+++ b/pkg/api/alertmanager.go
@@ -34,7 +34,7 @@ import (
 //       200: Ack
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{Recipient}/api/v2/alerts alertmanager RouteGetAmAlerts
+// swagger:route GET /alertmanager/{Recipient}/api/v2/alerts alertmanager RouteGetAMAlerts
 //
 // get alertmanager alerts
 //
@@ -42,7 +42,7 @@ import (
 //       200: GettableAlerts
 //       400: ValidationError
 
-// swagger:route POST /alertmanager/{Recipient}/api/v2/alerts alertmanager RoutePostAmAlerts
+// swagger:route POST /alertmanager/{Recipient}/api/v2/alerts alertmanager RoutePostAMAlerts
 //
 // create alertmanager alerts
 //
@@ -50,7 +50,7 @@ import (
 //       200: Ack
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{Recipient}/api/v2/alerts/groups alertmanager RouteGetAmAlertGroups
+// swagger:route GET /alertmanager/{Recipient}/api/v2/alerts/groups alertmanager RouteGetAMAlertGroups
 //
 // get alertmanager alerts
 //
@@ -120,7 +120,7 @@ type GettableAlerts amv2.GettableAlerts
 // swagger:model
 type AlertGroups amv2.AlertGroups
 
-// swagger:parameters RouteGetAmAlerts RouteGetAmAlertGroups
+// swagger:parameters RouteGetAMAlerts RouteGetAMAlertGroups
 type AlertsParams struct {
 
 	// Show active alerts
@@ -149,7 +149,7 @@ type AlertsParams struct {
 	Receivers []string `json:"receivers"`
 }
 
-// swagger:parameters RoutePostAmAlerts
+// swagger:parameters RoutePostAMAlerts
 type PostableAlerts struct {
 	// in:body
 	PostableAlerts []amv2.PostableAlert `yaml:"" json:""`
@@ -162,7 +162,7 @@ type BodyAlertingConfig struct {
 }
 
 // alertmanager routes
-// swagger:parameters RoutePostAlertingConfig RouteGetAlertingConfig RouteDeleteAlertingConfig RouteGetAmAlerts RoutePostAmAlerts RouteGetAmAlertGroups RouteGetSilences RouteCreateSilence RouteGetSilence RouteDeleteSilence RoutePostAlertingConfig
+// swagger:parameters RoutePostAlertingConfig RouteGetAlertingConfig RouteDeleteAlertingConfig RouteGetAMAlerts RoutePostAMAlerts RouteGetAMAlertGroups RouteGetSilences RouteCreateSilence RouteGetSilence RouteDeleteSilence RoutePostAlertingConfig
 // ruler routes
 // swagger:parameters RouteGetRulesConfig RoutePostNameRulesConfig RouteGetNamespaceRulesConfig RouteDeleteNamespaceRulesConfig RouteGetRulegGroupConfig RouteDeleteRuleGroupConfig
 // prom routes

--- a/post.json
+++ b/post.json
@@ -2161,7 +2161,6 @@
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2194,9 +2193,9 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object",
-   "x-go-package": "net/url"
+   "x-go-package": "github.com/prometheus/common/config"
   },
   "UpdateAlertDefinitionCommand": {
    "properties": {
@@ -2977,7 +2976,7 @@
   "/alertmanager/{Recipient}/api/v2/alerts": {
    "get": {
     "description": "get alertmanager alerts",
-    "operationId": "RouteGetAmAlerts",
+    "operationId": "RouteGetAMAlerts",
     "parameters": [
      {
       "description": "Show active alerts",
@@ -3048,7 +3047,7 @@
    },
    "post": {
     "description": "create alertmanager alerts",
-    "operationId": "RoutePostAmAlerts",
+    "operationId": "RoutePostAMAlerts",
     "parameters": [
      {
       "in": "body",
@@ -3090,7 +3089,7 @@
   "/alertmanager/{Recipient}/api/v2/alerts/groups": {
    "get": {
     "description": "get alertmanager alerts",
-    "operationId": "RouteGetAmAlertGroups",
+    "operationId": "RouteGetAMAlertGroups",
     "parameters": [
      {
       "description": "Show active alerts",

--- a/spec.json
+++ b/spec.json
@@ -22,7 +22,7 @@
         "tags": [
           "alertmanager"
         ],
-        "operationId": "RouteGetAmAlerts",
+        "operationId": "RouteGetAMAlerts",
         "parameters": [
           {
             "type": "boolean",
@@ -93,7 +93,7 @@
         "tags": [
           "alertmanager"
         ],
-        "operationId": "RoutePostAmAlerts",
+        "operationId": "RoutePostAMAlerts",
         "parameters": [
           {
             "name": "PostableAlerts",
@@ -135,7 +135,7 @@
         "tags": [
           "alertmanager"
         ],
-        "operationId": "RouteGetAmAlertGroups",
+        "operationId": "RouteGetAMAlertGroups",
         "parameters": [
           {
             "type": "boolean",
@@ -2945,9 +2945,8 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -2980,7 +2979,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "net/url"
+      "x-go-package": "github.com/prometheus/common/config"
     },
     "UpdateAlertDefinitionCommand": {
       "type": "object",


### PR DESCRIPTION
Update API to conform with GO conventions for [initialisms](https://github.com/golang/go/wiki/CodeReviewComments#initialisms)

This should affect only the generated server code (not the API spec)

See [comment](https://github.com/grafana/grafana/pull/32300#discussion_r603088883)