### PR TITLE
Fix empty POST /silences payload

### DIFF
--- a/post.json
+++ b/post.json
@@ -845,9 +845,7 @@
   "GettableSilence": {
    "$ref": "#/definitions/gettableSilence"
   },
-  "GettableSilences": {
-   "$ref": "#/definitions/gettableSilences"
-  },
+  "GettableSilences": {},
   "GettableUserConfig": {
    "properties": {
     "alertmanager_config": {
@@ -3240,7 +3238,7 @@
       "in": "body",
       "name": "Silence",
       "schema": {
-       "$ref": "#/definitions/PostableSilence"
+       "$ref": "#/definitions/postableSilence"
       }
      },
      {

--- a/spec.json
+++ b/spec.json
@@ -326,7 +326,7 @@
             "name": "Silence",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/PostableSilence"
+              "$ref": "#/definitions/postableSilence"
             }
           },
           {
@@ -1637,7 +1637,7 @@
       "$ref": "#/definitions/gettableSilence"
     },
     "GettableSilences": {
-      "$ref": "#/definitions/gettableSilences"
+      "$ref": "#/definitions/GettableSilences"
     },
     "GettableUserConfig": {
       "type": "object",


### PR DESCRIPTION
Fixes [POST /silences](https://grafana.github.io/alerting-api/#/alertmanager/RouteCreateSilence)
Recreating the generated JSON specs fixes the issue without further modifications