### PR TITLE
Prefix routes with /api

### DIFF
--- a/pkg/api/alertmanager.go
+++ b/pkg/api/alertmanager.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// swagger:route POST /alertmanager/{Recipient}/config/api/v1/alerts alertmanager RoutePostAlertingConfig
+// swagger:route POST /api/alertmanager/{Recipient}/config/api/v1/alerts alertmanager RoutePostAlertingConfig
 //
 // sets an Alerting config
 //
@@ -19,7 +19,7 @@ import (
 //       201: Ack
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{Recipient}/config/api/v1/alerts alertmanager RouteGetAlertingConfig
+// swagger:route GET /api/alertmanager/{Recipient}/config/api/v1/alerts alertmanager RouteGetAlertingConfig
 //
 // gets an Alerting config
 //
@@ -27,7 +27,7 @@ import (
 //       200: GettableUserConfig
 //       400: ValidationError
 
-// swagger:route DELETE /alertmanager/{Recipient}/config/api/v1/alerts alertmanager RouteDeleteAlertingConfig
+// swagger:route DELETE /api/alertmanager/{Recipient}/config/api/v1/alerts alertmanager RouteDeleteAlertingConfig
 //
 // deletes the Alerting config for a tenant
 //
@@ -35,7 +35,7 @@ import (
 //       200: Ack
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{Recipient}/api/v2/alerts alertmanager RouteGetAMAlerts
+// swagger:route GET /api/alertmanager/{Recipient}/api/v2/alerts alertmanager RouteGetAMAlerts
 //
 // get alertmanager alerts
 //
@@ -43,7 +43,7 @@ import (
 //       200: GettableAlerts
 //       400: ValidationError
 
-// swagger:route POST /alertmanager/{Recipient}/api/v2/alerts alertmanager RoutePostAMAlerts
+// swagger:route POST /api/alertmanager/{Recipient}/api/v2/alerts alertmanager RoutePostAMAlerts
 //
 // create alertmanager alerts
 //
@@ -51,7 +51,7 @@ import (
 //       200: Ack
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{Recipient}/api/v2/alerts/groups alertmanager RouteGetAMAlertGroups
+// swagger:route GET /api/alertmanager/{Recipient}/api/v2/alerts/groups alertmanager RouteGetAMAlertGroups
 //
 // get alertmanager alerts
 //
@@ -59,7 +59,7 @@ import (
 //       200: AlertGroups
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{Recipient}/api/v2/silences alertmanager RouteGetSilences
+// swagger:route GET /api/alertmanager/{Recipient}/api/v2/silences alertmanager RouteGetSilences
 //
 // get silences
 //
@@ -67,7 +67,7 @@ import (
 //       200: GettableSilences
 //       400: ValidationError
 
-// swagger:route POST /alertmanager/{Recipient}/api/v2/silences alertmanager RouteCreateSilence
+// swagger:route POST /api/alertmanager/{Recipient}/api/v2/silences alertmanager RouteCreateSilence
 //
 // create silence
 //
@@ -75,7 +75,7 @@ import (
 //       201: GettableSilence
 //       400: ValidationError
 
-// swagger:route GET /alertmanager/{Recipient}/api/v2/silence/{SilenceId} alertmanager RouteGetSilence
+// swagger:route GET /api/alertmanager/{Recipient}/api/v2/silence/{SilenceId} alertmanager RouteGetSilence
 //
 // get silence
 //
@@ -83,7 +83,7 @@ import (
 //       200: GettableSilence
 //       400: ValidationError
 
-// swagger:route DELETE /alertmanager/{Recipient}/api/v2/silence/{SilenceId} alertmanager RouteDeleteSilence
+// swagger:route DELETE /api/alertmanager/{Recipient}/api/v2/silence/{SilenceId} alertmanager RouteDeleteSilence
 //
 // delete silence
 //

--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -9,7 +9,7 @@ import (
 	"github.com/prometheus/common/model"
 )
 
-// swagger:route Get /ruler/{Recipient}/api/v1/rules ruler RouteGetRulesConfig
+// swagger:route Get /api/ruler/{Recipient}/api/v1/rules ruler RouteGetRulesConfig
 //
 // List rule groups
 //
@@ -19,7 +19,7 @@ import (
 //     Responses:
 //       202: NamespaceConfigResponse
 
-// swagger:route POST /ruler/{Recipient}/api/v1/rules/{Namespace} ruler RoutePostNameRulesConfig
+// swagger:route POST /api/ruler/{Recipient}/api/v1/rules/{Namespace} ruler RoutePostNameRulesConfig
 //
 // Creates or updates a rule group
 //
@@ -30,7 +30,7 @@ import (
 //     Responses:
 //       202: Ack
 
-// swagger:route Get /ruler/{Recipient}/api/v1/rules/{Namespace} ruler RouteGetNamespaceRulesConfig
+// swagger:route Get /api/ruler/{Recipient}/api/v1/rules/{Namespace} ruler RouteGetNamespaceRulesConfig
 //
 // Get rule groups by namespace
 //
@@ -40,14 +40,14 @@ import (
 //     Responses:
 //       202: NamespaceConfigResponse
 
-// swagger:route Delete /ruler/{Recipient}/api/v1/rules/{Namespace} ruler RouteDeleteNamespaceRulesConfig
+// swagger:route Delete /api/ruler/{Recipient}/api/v1/rules/{Namespace} ruler RouteDeleteNamespaceRulesConfig
 //
 // Delete namespace
 //
 //     Responses:
 //       202: Ack
 
-// swagger:route Get /ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname} ruler RouteGetRulegGroupConfig
+// swagger:route Get /api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname} ruler RouteGetRulegGroupConfig
 //
 // Get rule group
 //
@@ -57,7 +57,7 @@ import (
 //     Responses:
 //       202: RuleGroupConfigResponse
 
-// swagger:route Delete /ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname} ruler RouteDeleteRuleGroupConfig
+// swagger:route Delete /api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname} ruler RouteDeleteRuleGroupConfig
 //
 // Delete rule group
 //

--- a/pkg/api/prom.go
+++ b/pkg/api/prom.go
@@ -6,14 +6,14 @@ import (
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
-// swagger:route GET /prometheus/{Recipient}/api/v1/rules prometheus RouteGetRuleStatuses
+// swagger:route GET /api/prometheus/{Recipient}/api/v1/rules prometheus RouteGetRuleStatuses
 //
 // gets the evaluation statuses of all rules
 //
 //     Responses:
 //       200: RuleResponse
 
-// swagger:route GET /prometheus/{Recipient}/api/v1/alerts prometheus RouteGetAlertStatuses
+// swagger:route GET /api/prometheus/{Recipient}/api/v1/alerts prometheus RouteGetAlertStatuses
 //
 // gets the current alerts
 //

--- a/post.json
+++ b/post.json
@@ -820,9 +820,7 @@
    "type": "object",
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
-  "GettableSilence": {
-   "$ref": "#/definitions/gettableSilence"
-  },
+  "GettableSilence": {},
   "GettableSilences": {},
   "GettableUserConfig": {
    "properties": {
@@ -2959,7 +2957,7 @@
   "version": "1.0.0"
  },
  "paths": {
-  "/alertmanager/{Recipient}/api/v2/alerts": {
+  "/api/alertmanager/{Recipient}/api/v2/alerts": {
    "get": {
     "description": "get alertmanager alerts",
     "operationId": "RouteGetAMAlerts",
@@ -3072,7 +3070,7 @@
     ]
    }
   },
-  "/alertmanager/{Recipient}/api/v2/alerts/groups": {
+  "/api/alertmanager/{Recipient}/api/v2/alerts/groups": {
    "get": {
     "description": "get alertmanager alerts",
     "operationId": "RouteGetAMAlertGroups",
@@ -3145,7 +3143,7 @@
     ]
    }
   },
-  "/alertmanager/{Recipient}/api/v2/silence/{SilenceId}": {
+  "/api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}": {
    "delete": {
     "description": "delete silence",
     "operationId": "RouteDeleteSilence",
@@ -3219,7 +3217,7 @@
     ]
    }
   },
-  "/alertmanager/{Recipient}/api/v2/silences": {
+  "/api/alertmanager/{Recipient}/api/v2/silences": {
    "get": {
     "description": "get silences",
     "operationId": "RouteGetSilences",
@@ -3266,7 +3264,7 @@
       "in": "body",
       "name": "Silence",
       "schema": {
-       "$ref": "#/definitions/postableSilence"
+       "$ref": "#/definitions/PostableSilence"
       }
      },
      {
@@ -3296,7 +3294,7 @@
     ]
    }
   },
-  "/alertmanager/{Recipient}/config/api/v1/alerts": {
+  "/api/alertmanager/{Recipient}/config/api/v1/alerts": {
    "delete": {
     "description": "deletes the Alerting config for a tenant",
     "operationId": "RouteDeleteAlertingConfig",
@@ -3395,83 +3393,7 @@
     ]
    }
   },
-  "/api/v1/receiver/test": {
-   "post": {
-    "consumes": [
-     "application/json"
-    ],
-    "description": "Test receiver",
-    "operationId": "RouteTestReceiverConfig",
-    "parameters": [
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/ExtendedReceiver"
-      }
-     }
-    ],
-    "produces": [
-     "application/json"
-    ],
-    "responses": {
-     "200": {
-      "description": "Success",
-      "schema": {
-       "$ref": "#/definitions/Success"
-      }
-     },
-     "412": {
-      "description": "SmtpNotEnabled",
-      "schema": {
-       "$ref": "#/definitions/SmtpNotEnabled"
-      }
-     },
-     "500": {
-      "description": "Failure",
-      "schema": {
-       "$ref": "#/definitions/Failure"
-      }
-     }
-    },
-    "tags": [
-     "testing"
-    ]
-   }
-  },
-  "/api/v1/rule/test": {
-   "post": {
-    "consumes": [
-     "application/json"
-    ],
-    "description": "Test rule",
-    "operationId": "RouteTestRuleConfig",
-    "parameters": [
-     {
-      "in": "body",
-      "name": "Body",
-      "schema": {
-       "$ref": "#/definitions/TestRulePayload"
-      }
-     }
-    ],
-    "produces": [
-     "application/json"
-    ],
-    "responses": {
-     "200": {
-      "description": "TestRuleResponse",
-      "schema": {
-       "$ref": "#/definitions/TestRuleResponse"
-      }
-     }
-    },
-    "tags": [
-     "testing"
-    ]
-   }
-  },
-  "/prometheus/{Recipient}/api/v1/alerts": {
+  "/api/prometheus/{Recipient}/api/v1/alerts": {
    "get": {
     "description": "gets the current alerts",
     "operationId": "RouteGetAlertStatuses",
@@ -3497,7 +3419,7 @@
     ]
    }
   },
-  "/prometheus/{Recipient}/api/v1/rules": {
+  "/api/prometheus/{Recipient}/api/v1/rules": {
    "get": {
     "description": "gets the evaluation statuses of all rules",
     "operationId": "RouteGetRuleStatuses",
@@ -3523,7 +3445,7 @@
     ]
    }
   },
-  "/ruler/{Recipient}/api/v1/rules": {
+  "/api/ruler/{Recipient}/api/v1/rules": {
    "get": {
     "description": "List rule groups",
     "operationId": "RouteGetRulesConfig",
@@ -3552,7 +3474,7 @@
     ]
    }
   },
-  "/ruler/{Recipient}/api/v1/rules/{Namespace}": {
+  "/api/ruler/{Recipient}/api/v1/rules/{Namespace}": {
    "delete": {
     "description": "Delete namespace",
     "operationId": "RouteDeleteNamespaceRulesConfig",
@@ -3658,7 +3580,7 @@
     ]
    }
   },
-  "/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}": {
+  "/api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}": {
    "delete": {
     "description": "Delete rule group",
     "operationId": "RouteDeleteRuleGroupConfig",
@@ -3732,6 +3654,82 @@
     },
     "tags": [
      "ruler"
+    ]
+   }
+  },
+  "/api/v1/receiver/test": {
+   "post": {
+    "consumes": [
+     "application/json"
+    ],
+    "description": "Test receiver",
+    "operationId": "RouteTestReceiverConfig",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/ExtendedReceiver"
+      }
+     }
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "responses": {
+     "200": {
+      "description": "Success",
+      "schema": {
+       "$ref": "#/definitions/Success"
+      }
+     },
+     "412": {
+      "description": "SmtpNotEnabled",
+      "schema": {
+       "$ref": "#/definitions/SmtpNotEnabled"
+      }
+     },
+     "500": {
+      "description": "Failure",
+      "schema": {
+       "$ref": "#/definitions/Failure"
+      }
+     }
+    },
+    "tags": [
+     "testing"
+    ]
+   }
+  },
+  "/api/v1/rule/test": {
+   "post": {
+    "consumes": [
+     "application/json"
+    ],
+    "description": "Test rule",
+    "operationId": "RouteTestRuleConfig",
+    "parameters": [
+     {
+      "in": "body",
+      "name": "Body",
+      "schema": {
+       "$ref": "#/definitions/TestRulePayload"
+      }
+     }
+    ],
+    "produces": [
+     "application/json"
+    ],
+    "responses": {
+     "200": {
+      "description": "TestRuleResponse",
+      "schema": {
+       "$ref": "#/definitions/TestRuleResponse"
+      }
+     }
+    },
+    "tags": [
+     "testing"
     ]
    }
   }

--- a/spec.json
+++ b/spec.json
@@ -16,7 +16,7 @@
   },
   "basePath": "/api/v1",
   "paths": {
-    "/alertmanager/{Recipient}/api/v2/alerts": {
+    "/api/alertmanager/{Recipient}/api/v2/alerts": {
       "get": {
         "description": "get alertmanager alerts",
         "tags": [
@@ -129,7 +129,7 @@
         }
       }
     },
-    "/alertmanager/{Recipient}/api/v2/alerts/groups": {
+    "/api/alertmanager/{Recipient}/api/v2/alerts/groups": {
       "get": {
         "description": "get alertmanager alerts",
         "tags": [
@@ -202,7 +202,7 @@
         }
       }
     },
-    "/alertmanager/{Recipient}/api/v2/silence/{SilenceId}": {
+    "/api/alertmanager/{Recipient}/api/v2/silence/{SilenceId}": {
       "get": {
         "description": "get silence",
         "tags": [
@@ -276,7 +276,7 @@
         }
       }
     },
-    "/alertmanager/{Recipient}/api/v2/silences": {
+    "/api/alertmanager/{Recipient}/api/v2/silences": {
       "get": {
         "description": "get silences",
         "tags": [
@@ -326,7 +326,7 @@
             "name": "Silence",
             "in": "body",
             "schema": {
-              "$ref": "#/definitions/postableSilence"
+              "$ref": "#/definitions/PostableSilence"
             }
           },
           {
@@ -353,7 +353,7 @@
         }
       }
     },
-    "/alertmanager/{Recipient}/config/api/v1/alerts": {
+    "/api/alertmanager/{Recipient}/config/api/v1/alerts": {
       "get": {
         "description": "gets an Alerting config",
         "tags": [
@@ -452,83 +452,7 @@
         }
       }
     },
-    "/api/v1/receiver/test": {
-      "post": {
-        "description": "Test receiver",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "testing"
-        ],
-        "operationId": "RouteTestReceiverConfig",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/ExtendedReceiver"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Success",
-            "schema": {
-              "$ref": "#/definitions/Success"
-            }
-          },
-          "412": {
-            "description": "SmtpNotEnabled",
-            "schema": {
-              "$ref": "#/definitions/SmtpNotEnabled"
-            }
-          },
-          "500": {
-            "description": "Failure",
-            "schema": {
-              "$ref": "#/definitions/Failure"
-            }
-          }
-        }
-      }
-    },
-    "/api/v1/rule/test": {
-      "post": {
-        "description": "Test rule",
-        "consumes": [
-          "application/json"
-        ],
-        "produces": [
-          "application/json"
-        ],
-        "tags": [
-          "testing"
-        ],
-        "operationId": "RouteTestRuleConfig",
-        "parameters": [
-          {
-            "name": "Body",
-            "in": "body",
-            "schema": {
-              "$ref": "#/definitions/TestRulePayload"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "TestRuleResponse",
-            "schema": {
-              "$ref": "#/definitions/TestRuleResponse"
-            }
-          }
-        }
-      }
-    },
-    "/prometheus/{Recipient}/api/v1/alerts": {
+    "/api/prometheus/{Recipient}/api/v1/alerts": {
       "get": {
         "description": "gets the current alerts",
         "tags": [
@@ -554,7 +478,7 @@
         }
       }
     },
-    "/prometheus/{Recipient}/api/v1/rules": {
+    "/api/prometheus/{Recipient}/api/v1/rules": {
       "get": {
         "description": "gets the evaluation statuses of all rules",
         "tags": [
@@ -580,7 +504,7 @@
         }
       }
     },
-    "/ruler/{Recipient}/api/v1/rules": {
+    "/api/ruler/{Recipient}/api/v1/rules": {
       "get": {
         "description": "List rule groups",
         "produces": [
@@ -609,7 +533,7 @@
         }
       }
     },
-    "/ruler/{Recipient}/api/v1/rules/{Namespace}": {
+    "/api/ruler/{Recipient}/api/v1/rules/{Namespace}": {
       "get": {
         "description": "Get rule groups by namespace",
         "produces": [
@@ -715,7 +639,7 @@
         }
       }
     },
-    "/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}": {
+    "/api/ruler/{Recipient}/api/v1/rules/{Namespace}/{Groupname}": {
       "get": {
         "description": "Get rule group",
         "produces": [
@@ -787,6 +711,82 @@
             "description": "Ack",
             "schema": {
               "$ref": "#/definitions/Ack"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/receiver/test": {
+      "post": {
+        "description": "Test receiver",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "testing"
+        ],
+        "operationId": "RouteTestReceiverConfig",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/ExtendedReceiver"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "schema": {
+              "$ref": "#/definitions/Success"
+            }
+          },
+          "412": {
+            "description": "SmtpNotEnabled",
+            "schema": {
+              "$ref": "#/definitions/SmtpNotEnabled"
+            }
+          },
+          "500": {
+            "description": "Failure",
+            "schema": {
+              "$ref": "#/definitions/Failure"
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/rule/test": {
+      "post": {
+        "description": "Test rule",
+        "consumes": [
+          "application/json"
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "tags": [
+          "testing"
+        ],
+        "operationId": "RouteTestRuleConfig",
+        "parameters": [
+          {
+            "name": "Body",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/TestRulePayload"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "TestRuleResponse",
+            "schema": {
+              "$ref": "#/definitions/TestRuleResponse"
             }
           }
         }
@@ -1612,7 +1612,7 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "GettableSilence": {
-      "$ref": "#/definitions/gettableSilence"
+      "$ref": "#/definitions/GettableSilence"
     },
     "GettableSilences": {
       "$ref": "#/definitions/GettableSilences"


### PR DESCRIPTION
Following [this](https://github.com/grafana/grafana/pull/32688#discussion_r607052032) discussion.

Prefix all routes with `/api`. That is required for grafana detecting that it's an API request so that it will return 401 status for unauthorised requests instead of redirecting to login page.