### PR TITLE
Ruler: add For and Annotations inside Grafana alert

### DIFF
--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -289,9 +289,8 @@ type PostableGrafanaRule struct {
 	UID          string              `json:"uid" yaml:"uid"`
 	NoDataState  NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
-	// Receivers are used for migrating notification channels of existing alerts
-	// Do we still need this?
-	// Receivers []string
+	For          model.Duration      `json:"for" yaml:"for"`
+	Annotations  map[string]string   `json:"annotations" yaml:"annotations"`
 }
 
 // swagger:model
@@ -309,7 +308,6 @@ type GettableGrafanaRule struct {
 	RuleGroup       string              `json:"rule_group" yaml:"rule_group"`
 	NoDataState     NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState    ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
-	// Receivers are used for migrating notification channels of existing alerts
-	// Do we still need this?
-	// Receivers []string
+	For             model.Duration      `json:"for" yaml:"for"`
+	Annotations     map[string]string   `json:"annotations" yaml:"annotations"`
 }

--- a/post.json
+++ b/post.json
@@ -57,10 +57,10 @@
    "type": "object",
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
-  "AlertGroup": {
-   "$ref": "#/definitions/alertGroup"
+  "AlertGroup": {},
+  "AlertGroups": {
+   "$ref": "#/definitions/alertGroups"
   },
-  "AlertGroups": {},
   "AlertInstancesResponse": {
    "properties": {
     "instances": {
@@ -560,9 +560,7 @@
   "Failure": {
    "$ref": "#/definitions/ResponseDetails"
   },
-  "GettableAlert": {
-   "$ref": "#/definitions/gettableAlert"
-  },
+  "GettableAlert": {},
   "GettableAlerts": {},
   "GettableApiAlertingConfig": {
    "properties": {
@@ -728,6 +726,13 @@
   },
   "GettableGrafanaRule": {
    "properties": {
+    "annotations": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object",
+     "x-go-name": "Annotations"
+    },
     "condition": {
      "type": "string",
      "x-go-name": "Condition"
@@ -746,6 +751,9 @@
      ],
      "type": "string",
      "x-go-name": "ExecErrState"
+    },
+    "for": {
+     "$ref": "#/definitions/Duration"
     },
     "id": {
      "format": "int64",
@@ -822,8 +830,12 @@
    "type": "object",
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
-  "GettableSilence": {},
-  "GettableSilences": {},
+  "GettableSilence": {
+   "$ref": "#/definitions/gettableSilence"
+  },
+  "GettableSilences": {
+   "$ref": "#/definitions/gettableSilences"
+  },
   "GettableUserConfig": {
    "properties": {
     "alertmanager_config": {
@@ -1467,6 +1479,13 @@
   },
   "PostableGrafanaRule": {
    "properties": {
+    "annotations": {
+     "additionalProperties": {
+      "type": "string"
+     },
+     "type": "object",
+     "x-go-name": "Annotations"
+    },
     "condition": {
      "type": "string",
      "x-go-name": "Condition"
@@ -1485,6 +1504,9 @@
      ],
      "type": "string",
      "x-go-name": "ExecErrState"
+    },
+    "for": {
+     "$ref": "#/definitions/Duration"
     },
     "no_data_state": {
      "enum": [
@@ -2597,7 +2619,7 @@
   "gettableAlerts": {
    "description": "GettableAlerts gettable alerts",
    "items": {
-    "$ref": "#/definitions/GettableAlert"
+    "$ref": "#/definitions/gettableAlert"
    },
    "type": "array",
    "x-go-name": "GettableAlerts",

--- a/spec.json
+++ b/spec.json
@@ -849,10 +849,10 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "AlertGroup": {
-      "$ref": "#/definitions/alertGroup"
+      "$ref": "#/definitions/AlertGroup"
     },
     "AlertGroups": {
-      "$ref": "#/definitions/AlertGroups"
+      "$ref": "#/definitions/alertGroups"
     },
     "AlertInstancesResponse": {
       "type": "object",
@@ -1355,7 +1355,7 @@
       "$ref": "#/definitions/ResponseDetails"
     },
     "GettableAlert": {
-      "$ref": "#/definitions/gettableAlert"
+      "$ref": "#/definitions/GettableAlert"
     },
     "GettableAlerts": {
       "$ref": "#/definitions/GettableAlerts"
@@ -1525,6 +1525,13 @@
     "GettableGrafanaRule": {
       "type": "object",
       "properties": {
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "condition": {
           "type": "string",
           "x-go-name": "Condition"
@@ -1543,6 +1550,9 @@
             "KeepLastState"
           ],
           "x-go-name": "ExecErrState"
+        },
+        "for": {
+          "$ref": "#/definitions/Duration"
         },
         "id": {
           "type": "integer",
@@ -1619,10 +1629,10 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "GettableSilence": {
-      "$ref": "#/definitions/GettableSilence"
+      "$ref": "#/definitions/gettableSilence"
     },
     "GettableSilences": {
-      "$ref": "#/definitions/GettableSilences"
+      "$ref": "#/definitions/gettableSilences"
     },
     "GettableUserConfig": {
       "type": "object",
@@ -2269,6 +2279,13 @@
     "PostableGrafanaRule": {
       "type": "object",
       "properties": {
+        "annotations": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "x-go-name": "Annotations"
+        },
         "condition": {
           "type": "string",
           "x-go-name": "Condition"
@@ -2287,6 +2304,9 @@
             "KeepLastState"
           ],
           "x-go-name": "ExecErrState"
+        },
+        "for": {
+          "$ref": "#/definitions/Duration"
         },
         "no_data_state": {
           "type": "string",
@@ -3399,7 +3419,7 @@
       "description": "GettableAlerts gettable alerts",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/GettableAlert"
+        "$ref": "#/definitions/gettableAlert"
       },
       "x-go-name": "GettableAlerts",
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"


### PR DESCRIPTION
Grafana alerts have For and `alertRuleTags`, which I think correspond to annotations. So this add those properties.

Alternatively we could pull them from the for and annotation fields of the prom part of the rules, but the API current switches on those properties so sofia and I thought this may be clearer.