### PR TITLE
Fix grafana rule For field type

### DIFF
--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -289,7 +289,7 @@ type PostableGrafanaRule struct {
 	UID          string              `json:"uid" yaml:"uid"`
 	NoDataState  NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
-	For          model.Duration      `json:"for" yaml:"for"`
+	For          models.Duration     `json:"for" yaml:"for"`
 	Annotations  map[string]string   `json:"annotations" yaml:"annotations"`
 }
 
@@ -308,6 +308,6 @@ type GettableGrafanaRule struct {
 	RuleGroup       string              `json:"rule_group" yaml:"rule_group"`
 	NoDataState     NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState    ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`
-	For             model.Duration      `json:"for" yaml:"for"`
+	For             models.Duration     `json:"for" yaml:"for"`
 	Annotations     map[string]string   `json:"annotations" yaml:"annotations"`
 }

--- a/post.json
+++ b/post.json
@@ -57,7 +57,9 @@
    "type": "object",
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
-  "AlertGroup": {},
+  "AlertGroup": {
+   "$ref": "#/definitions/alertGroup"
+  },
   "AlertGroups": {
    "$ref": "#/definitions/alertGroups"
   },
@@ -429,8 +431,8 @@
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
   "Duration": {
+   "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
    "format": "int64",
-   "title": "Duration is a type used for marshalling durations.",
    "type": "integer"
   },
   "EmailConfig": {
@@ -561,7 +563,9 @@
    "$ref": "#/definitions/ResponseDetails"
   },
   "GettableAlert": {},
-  "GettableAlerts": {},
+  "GettableAlerts": {
+   "$ref": "#/definitions/gettableAlerts"
+  },
   "GettableApiAlertingConfig": {
    "properties": {
     "global": {
@@ -1550,9 +1554,7 @@
    "type": "object",
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
-  "PostableSilence": {
-   "$ref": "#/definitions/postableSilence"
-  },
+  "PostableSilence": {},
   "PostableUserConfig": {
    "properties": {
     "alertmanager_config": {
@@ -2201,7 +2203,6 @@
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
   "URL": {
-   "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
    "properties": {
     "ForceQuery": {
      "type": "boolean"
@@ -2234,9 +2235,9 @@
      "$ref": "#/definitions/Userinfo"
     }
    },
-   "title": "A URL represents a parsed URL (technically, a URI reference).",
+   "title": "URL is a custom URL type that allows validation at configuration load time.",
    "type": "object",
-   "x-go-package": "net/url"
+   "x-go-package": "github.com/prometheus/common/config"
   },
   "Userinfo": {
    "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -2414,7 +2415,7 @@
      "$ref": "#/definitions/labelSet"
     },
     "receiver": {
-     "$ref": "#/definitions/receiver"
+     "$ref": "#/definitions/Receiver"
     }
    },
    "required": [
@@ -2685,7 +2686,7 @@
   "gettableSilences": {
    "description": "GettableSilences gettable silences",
    "items": {
-    "$ref": "#/definitions/gettableSilence"
+    "$ref": "#/definitions/GettableSilence"
    },
    "type": "array",
    "x-go-name": "GettableSilences",

--- a/spec.json
+++ b/spec.json
@@ -849,7 +849,7 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "AlertGroup": {
-      "$ref": "#/definitions/AlertGroup"
+      "$ref": "#/definitions/alertGroup"
     },
     "AlertGroups": {
       "$ref": "#/definitions/alertGroups"
@@ -1222,9 +1222,9 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "Duration": {
+      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
       "type": "integer",
       "format": "int64",
-      "title": "Duration is a type used for marshalling durations.",
       "$ref": "#/definitions/Duration"
     },
     "EmailConfig": {
@@ -1358,7 +1358,7 @@
       "$ref": "#/definitions/GettableAlert"
     },
     "GettableAlerts": {
-      "$ref": "#/definitions/GettableAlerts"
+      "$ref": "#/definitions/gettableAlerts"
     },
     "GettableApiAlertingConfig": {
       "type": "object",
@@ -2350,7 +2350,7 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "PostableSilence": {
-      "$ref": "#/definitions/postableSilence"
+      "$ref": "#/definitions/PostableSilence"
     },
     "PostableUserConfig": {
       "type": "object",
@@ -3000,9 +3000,8 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "URL": {
-      "description": "The general form represented is:\n\n[scheme:][//[userinfo@]host][/]path[?query][#fragment]\n\nURLs that do not start with a slash after the scheme are interpreted as:\n\nscheme:opaque[?query][#fragment]\n\nNote that the Path field is stored in decoded form: /%47%6f%2f becomes /Go/.\nA consequence is that it is impossible to tell which slashes in the Path were\nslashes in the raw URL and which were %2f. This distinction is rarely important,\nbut when it is, the code should use RawPath, an optional field which only gets\nset if the default encoding is different from Path.\n\nURL's String method uses the EscapedPath method to obtain the path. See the\nEscapedPath method for more details.",
       "type": "object",
-      "title": "A URL represents a parsed URL (technically, a URI reference).",
+      "title": "URL is a custom URL type that allows validation at configuration load time.",
       "properties": {
         "ForceQuery": {
           "type": "boolean"
@@ -3035,7 +3034,7 @@
           "$ref": "#/definitions/Userinfo"
         }
       },
-      "x-go-package": "net/url"
+      "x-go-package": "github.com/prometheus/common/config"
     },
     "Userinfo": {
       "description": "The Userinfo type is an immutable encapsulation of username and\npassword details for a URL. An existing Userinfo value is guaranteed\nto have a username set (potentially empty, as allowed by RFC 2396),\nand optionally a password.",
@@ -3219,7 +3218,7 @@
           "$ref": "#/definitions/labelSet"
         },
         "receiver": {
-          "$ref": "#/definitions/receiver"
+          "$ref": "#/definitions/Receiver"
         }
       },
       "x-go-name": "AlertGroup",
@@ -3485,7 +3484,7 @@
       "description": "GettableSilences gettable silences",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/gettableSilence"
+        "$ref": "#/definitions/GettableSilence"
       },
       "x-go-name": "GettableSilences",
       "x-go-package": "github.com/prometheus/alertmanager/api/v2/models"


### PR DESCRIPTION
Change `For` field in `PostableGrafanaRule` and `GettableGrafanaRule` to [this](https://github.com/grafana/grafana/blob/458681c4242022e802d1c1bac4358647778106b6/pkg/services/ngalert/models/alert_query.go#L16) Duration type which implements the JSON Marshaler and Unmarshaler interfaces