### PR TITLE
Ruler API modifications

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1293,6 +1293,7 @@ github.com/prometheus/prometheus v1.8.2-0.20201014093524-73e2ce1bd643 h1:BDAexvK
 github.com/prometheus/prometheus v1.8.2-0.20201014093524-73e2ce1bd643/go.mod h1:XYjkJiog7fyQu3puQNivZPI2pNq1C/775EIoHfDvuvY=
 github.com/prometheus/prometheus v1.8.2-0.20201105135750-00f16d1ac3a4 h1:54z99l8Q3TuyyeoNZkyY4Lq7eFht9J2Mynq4T1Hxbzc=
 github.com/prometheus/prometheus v1.8.2-0.20201105135750-00f16d1ac3a4/go.mod h1:XYjkJiog7fyQu3puQNivZPI2pNq1C/775EIoHfDvuvY=
+github.com/prometheus/prometheus v1.8.2 h1:PAL466mnJw1VolZPm1OarpdUpqukUy/eX4tagia17DM=
 github.com/prometheus/statsd_exporter v0.15.0/go.mod h1:Dv8HnkoLQkeEjkIE4/2ndAA7WL1zHKK7WMqFQqu72rw=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/quasilyte/go-ruleguard/dsl/fluent v0.0.0-20201222093424-5d7e62a465d3/go.mod h1:P7JlQWFT7jDcFZMtUPQbtGzzzxva3rBn6oIF+LPwFcM=

--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -363,6 +363,7 @@ type GettableGrafanaRule struct {
 	Version         int64               `json:"version" yaml:"version"`
 	UID             string              `json:"uid" yaml:"uid"`
 	NamespaceUID    string              `json:"namespace_uid" yaml:"namespace_uid"`
+	NamespaceID     int64               `json:"namespace_id" yaml:"namespace_id"`
 	RuleGroup       string              `json:"rule_group" yaml:"rule_group"`
 	NoDataState     NoDataState         `json:"no_data_state" yaml:"no_data_state"`
 	ExecErrState    ExecutionErrorState `json:"exec_err_state" yaml:"exec_err_state"`

--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -96,8 +96,7 @@ type NamespaceConfigResponse map[string][]GettableRuleGroupConfig
 
 // swagger:model
 type PostableRuleGroupConfig struct {
-	Name string `yaml:"name" json:"name"`
-	// Example 1m
+	Name     string                     `yaml:"name" json:"name"`
 	Interval model.Duration             `yaml:"interval,omitempty" json:"interval,omitempty"`
 	Rules    []PostableExtendedRuleNode `yaml:"rules" json:"rules"`
 }
@@ -188,10 +187,9 @@ func (c *GettableRuleGroupConfig) validate() error {
 }
 
 type ApiRuleNode struct {
-	Record string `yaml:"record,omitempty" json:"record,omitempty"`
-	Alert  string `yaml:"alert,omitempty" json:"alert,omitempty"`
-	Expr   string `yaml:"expr" json:"expr"`
-	// Example: 1m
+	Record      string            `yaml:"record,omitempty" json:"record,omitempty"`
+	Alert       string            `yaml:"alert,omitempty" json:"alert,omitempty"`
+	Expr        string            `yaml:"expr" json:"expr"`
 	For         model.Duration    `yaml:"for,omitempty" json:"for,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`

--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -114,11 +114,7 @@ func (c *PostableRuleGroupConfig) UnmarshalJSON(b []byte) error {
 // Type requires validate has been called and just checks the first rule type
 func (c *PostableRuleGroupConfig) Type() (backend Backend, err error) {
 	for _, rule := range c.Rules {
-		b, err := rule.Type()
-		if err != nil {
-			return backend, err
-		}
-		switch b {
+		switch rule.Type() {
 		case GrafanaManagedRule:
 			return GrafanaBackend, nil
 		case LoTexManagedRule:
@@ -131,11 +127,7 @@ func (c *PostableRuleGroupConfig) Type() (backend Backend, err error) {
 func (c *PostableRuleGroupConfig) validate() error {
 	var hasGrafRules, hasLotexRules bool
 	for _, rule := range c.Rules {
-		b, err := rule.Type()
-		if err != nil {
-			return err
-		}
-		switch b {
+		switch rule.Type() {
 		case GrafanaManagedRule:
 			hasGrafRules = true
 		case LoTexManagedRule:
@@ -219,18 +211,12 @@ type PostableExtendedRuleNode struct {
 	GrafanaManagedAlert *PostableGrafanaRule `yaml:"grafana_alert,omitempty" json:"grafana_alert,omitempty"`
 }
 
-func (n *PostableExtendedRuleNode) Type() (RuleType, error) {
-	if n.ApiRuleNode == nil && n.GrafanaManagedAlert == nil {
-		return 0, fmt.Errorf("cannot have empty rule")
+func (n *PostableExtendedRuleNode) Type() RuleType {
+	if n.GrafanaManagedAlert != nil {
+		return GrafanaManagedRule
 	}
 
-	if n.GrafanaManagedAlert != nil {
-		if n.ApiRuleNode != nil && (n.ApiRuleNode.Expr != "" || n.ApiRuleNode.Record != "") {
-			return 0, fmt.Errorf("cannot have both Prometheus style rules and Grafana rules together")
-		}
-		return GrafanaManagedRule, nil
-	}
-	return LoTexManagedRule, nil
+	return LoTexManagedRule
 }
 
 func (n *PostableExtendedRuleNode) UnmarshalJSON(b []byte) error {

--- a/pkg/api/cortex-ruler.go
+++ b/pkg/api/cortex-ruler.go
@@ -112,13 +112,13 @@ func (c *PostableRuleGroupConfig) UnmarshalJSON(b []byte) error {
 }
 
 // Type requires validate has been called and just checks the first rule type
-func (c *PostableRuleGroupConfig) Type() (backend Backend, err error) {
+func (c *PostableRuleGroupConfig) Type() (backend Backend) {
 	for _, rule := range c.Rules {
 		switch rule.Type() {
 		case GrafanaManagedRule:
-			return GrafanaBackend, nil
+			return GrafanaBackend
 		case LoTexManagedRule:
-			return LoTexRulerBackend, nil
+			return LoTexRulerBackend
 		}
 	}
 	return
@@ -158,13 +158,13 @@ func (c *GettableRuleGroupConfig) UnmarshalJSON(b []byte) error {
 }
 
 // Type requires validate has been called and just checks the first rule type
-func (c *GettableRuleGroupConfig) Type() (backend Backend, err error) {
+func (c *GettableRuleGroupConfig) Type() (backend Backend) {
 	for _, rule := range c.Rules {
 		switch rule.Type() {
 		case GrafanaManagedRule:
-			return GrafanaBackend, nil
+			return GrafanaBackend
 		case LoTexManagedRule:
-			return LoTexRulerBackend, nil
+			return LoTexRulerBackend
 		}
 	}
 	return

--- a/pkg/api/cortex-ruler_test.go
+++ b/pkg/api/cortex-ruler_test.go
@@ -50,7 +50,7 @@ func Test_Rule_Marshaling(t *testing.T) {
 			desc: "grafana with for, annotation and label properties",
 			input: PostableExtendedRuleNode{
 				ApiRuleNode: &ApiRuleNode{
-					For:         ApiDuration(dur),
+					For:         model.Duration(dur),
 					Annotations: map[string]string{"foo": "bar"},
 					Labels:      map[string]string{"label1": "val1"}},
 				GrafanaManagedAlert: &PostableGrafanaRule{},
@@ -121,7 +121,7 @@ func Test_Rule_Group_Marshaling(t *testing.T) {
 				Rules: []PostableExtendedRuleNode{
 					PostableExtendedRuleNode{
 						ApiRuleNode: &ApiRuleNode{
-							For:         ApiDuration(dur),
+							For:         model.Duration(dur),
 							Annotations: map[string]string{"foo": "bar"},
 							Labels:      map[string]string{"label1": "val1"},
 						},

--- a/pkg/api/cortex-ruler_test.go
+++ b/pkg/api/cortex-ruler_test.go
@@ -207,8 +207,7 @@ func Test_Rule_Group_Type(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			bt, err := tc.input.Type()
-			require.NoError(t, err)
+			bt := tc.input.Type()
 			require.Equal(t, tc.expected, bt)
 		})
 	}

--- a/post.json
+++ b/post.json
@@ -256,6 +256,10 @@
    "type": "object",
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
+  "ApiDuration": {
+   "$ref": "#/definitions/Duration",
+   "description": "ApiDuration extends model.Duration\nfor handling JSON serialization/deserialization"
+  },
   "ApiRuleNode": {
    "properties": {
     "alert": {
@@ -274,7 +278,7 @@
      "x-go-name": "Expr"
     },
     "for": {
-     "$ref": "#/definitions/Duration"
+     "$ref": "#/definitions/ApiDuration"
     },
     "labels": {
      "additionalProperties": {
@@ -692,7 +696,7 @@
      "x-go-name": "Expr"
     },
     "for": {
-     "$ref": "#/definitions/Duration"
+     "$ref": "#/definitions/ApiDuration"
     },
     "grafana_alert": {
      "$ref": "#/definitions/GettableGrafanaRule"
@@ -730,13 +734,6 @@
   },
   "GettableGrafanaRule": {
    "properties": {
-    "annotations": {
-     "additionalProperties": {
-      "type": "string"
-     },
-     "type": "object",
-     "x-go-name": "Annotations"
-    },
     "condition": {
      "type": "string",
      "x-go-name": "Condition"
@@ -755,9 +752,6 @@
      ],
      "type": "string",
      "x-go-name": "ExecErrState"
-    },
-    "for": {
-     "$ref": "#/definitions/Duration"
     },
     "id": {
      "format": "int64",
@@ -1428,7 +1422,7 @@
      "x-go-name": "Expr"
     },
     "for": {
-     "$ref": "#/definitions/Duration"
+     "$ref": "#/definitions/ApiDuration"
     },
     "grafana_alert": {
      "$ref": "#/definitions/PostableGrafanaRule"
@@ -1466,13 +1460,6 @@
   },
   "PostableGrafanaRule": {
    "properties": {
-    "annotations": {
-     "additionalProperties": {
-      "type": "string"
-     },
-     "type": "object",
-     "x-go-name": "Annotations"
-    },
     "condition": {
      "type": "string",
      "x-go-name": "Condition"
@@ -1491,9 +1478,6 @@
      ],
      "type": "string",
      "x-go-name": "ExecErrState"
-    },
-    "for": {
-     "$ref": "#/definitions/Duration"
     },
     "no_data_state": {
      "enum": [

--- a/post.json
+++ b/post.json
@@ -763,6 +763,11 @@
      "type": "integer",
      "x-go-name": "IntervalSeconds"
     },
+    "namespace_id": {
+     "format": "int64",
+     "type": "integer",
+     "x-go-name": "NamespaceID"
+    },
     "namespace_uid": {
      "type": "string",
      "x-go-name": "NamespaceUID"

--- a/post.json
+++ b/post.json
@@ -256,10 +256,6 @@
    "type": "object",
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
-  "ApiDuration": {
-   "$ref": "#/definitions/Duration",
-   "description": "ApiDuration extends model.Duration\nfor handling JSON serialization/deserialization"
-  },
   "ApiRuleNode": {
    "properties": {
     "alert": {
@@ -278,7 +274,7 @@
      "x-go-name": "Expr"
     },
     "for": {
-     "$ref": "#/definitions/ApiDuration"
+     "$ref": "#/definitions/Duration"
     },
     "labels": {
      "additionalProperties": {
@@ -435,8 +431,8 @@
    "x-go-package": "github.com/grafana/alerting-api/pkg/api"
   },
   "Duration": {
-   "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
    "format": "int64",
+   "title": "Duration is a type used for marshalling durations.",
    "type": "integer"
   },
   "EmailConfig": {
@@ -696,7 +692,7 @@
      "x-go-name": "Expr"
     },
     "for": {
-     "$ref": "#/definitions/ApiDuration"
+     "$ref": "#/definitions/Duration"
     },
     "grafana_alert": {
      "$ref": "#/definitions/GettableGrafanaRule"
@@ -1427,7 +1423,7 @@
      "x-go-name": "Expr"
     },
     "for": {
-     "$ref": "#/definitions/ApiDuration"
+     "$ref": "#/definitions/Duration"
     },
     "grafana_alert": {
      "$ref": "#/definitions/PostableGrafanaRule"

--- a/spec.json
+++ b/spec.json
@@ -1572,6 +1572,11 @@
           "format": "int64",
           "x-go-name": "IntervalSeconds"
         },
+        "namespace_id": {
+          "type": "integer",
+          "format": "int64",
+          "x-go-name": "NamespaceID"
+        },
         "namespace_uid": {
           "type": "string",
           "x-go-name": "NamespaceUID"

--- a/spec.json
+++ b/spec.json
@@ -1061,6 +1061,10 @@
       },
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
+    "ApiDuration": {
+      "description": "ApiDuration extends model.Duration\nfor handling JSON serialization/deserialization",
+      "$ref": "#/definitions/Duration"
+    },
     "ApiRuleNode": {
       "type": "object",
       "properties": {
@@ -1080,7 +1084,7 @@
           "x-go-name": "Expr"
         },
         "for": {
-          "$ref": "#/definitions/Duration"
+          "$ref": "#/definitions/ApiDuration"
         },
         "labels": {
           "type": "object",
@@ -1501,7 +1505,7 @@
           "x-go-name": "Expr"
         },
         "for": {
-          "$ref": "#/definitions/Duration"
+          "$ref": "#/definitions/ApiDuration"
         },
         "grafana_alert": {
           "$ref": "#/definitions/GettableGrafanaRule"
@@ -1539,13 +1543,6 @@
     "GettableGrafanaRule": {
       "type": "object",
       "properties": {
-        "annotations": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-name": "Annotations"
-        },
         "condition": {
           "type": "string",
           "x-go-name": "Condition"
@@ -1564,9 +1561,6 @@
             "KeepLastState"
           ],
           "x-go-name": "ExecErrState"
-        },
-        "for": {
-          "$ref": "#/definitions/Duration"
         },
         "id": {
           "type": "integer",
@@ -2240,7 +2234,7 @@
           "x-go-name": "Expr"
         },
         "for": {
-          "$ref": "#/definitions/Duration"
+          "$ref": "#/definitions/ApiDuration"
         },
         "grafana_alert": {
           "$ref": "#/definitions/PostableGrafanaRule"
@@ -2278,13 +2272,6 @@
     "PostableGrafanaRule": {
       "type": "object",
       "properties": {
-        "annotations": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "x-go-name": "Annotations"
-        },
         "condition": {
           "type": "string",
           "x-go-name": "Condition"
@@ -2303,9 +2290,6 @@
             "KeepLastState"
           ],
           "x-go-name": "ExecErrState"
-        },
-        "for": {
-          "$ref": "#/definitions/Duration"
         },
         "no_data_state": {
           "type": "string",

--- a/spec.json
+++ b/spec.json
@@ -1061,10 +1061,6 @@
       },
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
-    "ApiDuration": {
-      "description": "ApiDuration extends model.Duration\nfor handling JSON serialization/deserialization",
-      "$ref": "#/definitions/Duration"
-    },
     "ApiRuleNode": {
       "type": "object",
       "properties": {
@@ -1084,7 +1080,7 @@
           "x-go-name": "Expr"
         },
         "for": {
-          "$ref": "#/definitions/ApiDuration"
+          "$ref": "#/definitions/Duration"
         },
         "labels": {
           "type": "object",
@@ -1240,9 +1236,9 @@
       "x-go-package": "github.com/grafana/alerting-api/pkg/api"
     },
     "Duration": {
-      "description": "A Duration represents the elapsed time between two instants\nas an int64 nanosecond count. The representation limits the\nlargest representable duration to approximately 290 years.",
       "type": "integer",
       "format": "int64",
+      "title": "Duration is a type used for marshalling durations.",
       "$ref": "#/definitions/Duration"
     },
     "EmailConfig": {
@@ -1505,7 +1501,7 @@
           "x-go-name": "Expr"
         },
         "for": {
-          "$ref": "#/definitions/ApiDuration"
+          "$ref": "#/definitions/Duration"
         },
         "grafana_alert": {
           "$ref": "#/definitions/GettableGrafanaRule"
@@ -2239,7 +2235,7 @@
           "x-go-name": "Expr"
         },
         "for": {
-          "$ref": "#/definitions/ApiDuration"
+          "$ref": "#/definitions/Duration"
         },
         "grafana_alert": {
           "$ref": "#/definitions/PostableGrafanaRule"


### PR DESCRIPTION
- Add namespace id in `GettableGrafanaRule`
- Use common for, annotations and labels properties for grafana and lotex rules
- Removes the properties introduced in #45

I had to:
- modify the code for validating the payloads
- ~extend [model.Duration](https://pkg.go.dev/github.com/prometheus/common/model#Duration) type to implement the `json.Marshaler` and `json.Unmarshaler` interfaces~ This is finally not required (JSON unmarshalling works without it) so I have revert it.